### PR TITLE
docs: remove unsubstantiated pagination performance known-problem

### DIFF
--- a/Documentation/KnownProblems/Index.rst
+++ b/Documentation/KnownProblems/Index.rst
@@ -47,20 +47,6 @@ Import Performance
 
 **GitHub Issue:** `#30 <https://github.com/netresearch/t3x-nr-textdb/issues/30>`_
 
-Pagination with Large Datasets
--------------------------------
-
-**Issue:** Initial page load slow with >10,000 translation records
-
-**Workaround:**
-  * Use filters to narrow results
-  * Implement custom caching layer
-  * Consider database indexing optimization
-
-**Status:** Performance improvements planned for 3.1.0
-
-**GitHub Issue:** `#31 <https://github.com/netresearch/t3x-nr-textdb/issues/31>`_
-
 Language Fallback
 -----------------
 


### PR DESCRIPTION
## Summary

Removes the "Pagination with Large Datasets" entry from `Documentation/KnownProblems/Index.rst` and its link to #31.

## Rationale

The claim that *"initial page load is slow with >10,000 translation records"* was introduced in [`12cd7f4`](https://github.com/netresearch/t3x-nr-textdb/commit/12cd7f4) as part of a speculative documentation overhaul. It was never backed by a user-reported bug, profiling data, or reproduction recipe — the string `10,000` appears in no other commit or source file.

@sebastian-altenburg-nr tested empirically on 2026-04-17 ([comment on #31](https://github.com/netresearch/t3x-nr-textdb/issues/31#issuecomment-4267140002)):

- TYPO3 v13.4.28 / v14.2.0, PHP 8.4
- 15,000 and **1,135,000** translation records (113× the claimed threshold)
- `listAction` loads in **< 1 s** in all cases

The backend controller already uses TYPO3's standard `QueryResultPaginator` + `SimplePagination` (`Classes/Controller/TranslationController.php:948`), which fetches only one page at a time — so even the theoretical basis was weak.

Closes #31 (cannot-reproduce).

## Test plan

- [ ] Docs build succeeds (no dangling references)
- [ ] `KnownProblems/Index.rst` still renders with #30 and #32 sections intact