### PR TITLE
fix(ci): migrate release workflow to grouped release-typo3-extension caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
     permissions:
       contents: write
       id-token: write
@@ -17,21 +17,6 @@ jobs:
     with:
       archive-prefix: nr-textdb
       package-name: netresearch/nr-textdb
-
-  publish-to-ter:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
-    permissions:
-      contents: read
+      extension-key: nr_textdb
     secrets:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
-
-  slsa-provenance:
-    needs: release
-    uses: netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    with:
-      version: ${{ github.ref_name }}


### PR DESCRIPTION
## Problem

`release.yml` calls the reusable workflow `netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main`, which was removed from typo3-ci-workflows on 2026-03-14 (redundant with build-provenance attestations; fails on immutable releases). Since then every tag push fails at workflow validation with zero jobs executed — the same failure pattern as netresearch/t3x-nr-mcp-agent run 27428378711.

## Fix

Replace the three-job caller (`release.yml` + `publish-to-ter.yml` + `slsa-provenance.yml`) with the single grouped caller `release-typo3-extension.yml`, mirroring the pattern already in place in t3x-nr-passkeys-be and t3x-nr-mcp-agent:

- `archive-prefix: nr-textdb` (unchanged)
- `package-name: netresearch/nr-textdb` (unchanged)
- `extension-key: nr_textdb` (from composer.json; previously passed as the `TYPO3_EXTENSION_KEY` secret)
- `TYPO3_TER_ACCESS_TOKEN` secret retained (available as org secret)

No tags are created or moved by this PR.
