### PR TITLE
ci: adopt canonical typo3-extension template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,49 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# Managed by netresearch/.github/templates/typo3-extension/
+#
+# Declares only the ecosystems every typo3-extension consumer is guaranteed to
+# have: composer (the extension's composer.json) and github-actions.
+#
+# npm is OPT-IN: an extension that actually ships a package.json (frontend
+# assets) adds the block below to its own dependabot.yml and lists
+# `.github/dependabot.yml` under `intentional-drift:` in .github/template.yaml
+# so the template sync stops managing the file. Declaring an ecosystem without
+# its manifest makes the Dependabot run fail with `dependency_file_not_found`.
+#
+# Opt-in npm:
+#   - package-ecosystem: npm
+#     directory: /
+#     schedule:
+#       interval: weekly
+#       day: monday
+#     open-pull-requests-limit: 5
+#     groups:
+#       npm:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
 version: 2
 updates:
-  - package-ecosystem: "composer"
-    directory: "/"
+  - package-ecosystem: composer
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
     versioning-strategy: increase-if-necessary
+    groups:
+      composer:
+        patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
     groups:
       github-actions:
-        patterns:
-          - "*"
+        patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,17 @@
 # Label configuration for PR Labeler
 # https://github.com/actions/labeler
-
 documentation:
   - changed-files:
-      - any-glob-to-any-file:
-          - 'Documentation/**'
-          - '*.md'
-
+      - any-glob-to-any-file: ['Documentation/**/*', '**/*.md']
 tests:
   - changed-files:
-      - any-glob-to-any-file:
-          - 'Tests/**'
-          - 'Build/phpunit/**'
-
+      - any-glob-to-any-file: ['Tests/**/*', 'Build/phpunit/**/*']
 ci:
   - changed-files:
-      - any-glob-to-any-file:
-          - '.github/workflows/**'
-          - '.github/dependabot.yml'
-
+      - any-glob-to-any-file: ['.github/**/*', 'Build/**/*']
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ['composer.json', 'composer.lock', 'package.json', 'package-lock.json', 'yarn.lock']
 configuration:
   - changed-files:
-      - any-glob-to-any-file:
-          - 'Configuration/**'
-          - 'ext_*.php'
-          - 'composer.json'
+      - any-glob-to-any-file: ['Configuration/**/*', 'ext_*.php', 'composer.json']

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -1,0 +1,14 @@
+# Managed by netresearch/.github/templates/typo3-extension/
+# Drift from the template is blocking CI in this repo (check-template-drift.yml).
+# Record explicit exceptions under intentional-drift[] to unblock.
+#
+# All per-extension CI values (the PHP/TYPO3 test matrix and the release
+# metadata archive-prefix/package-name/extension-key) live in
+# `.github/typo3-ci.json`, NOT in the workflows — so ci.yml and release.yml
+# stay byte-identical and fully drift-enforced across every extension.
+# typo3-ci.json is listed under intentional-drift below: the template sync
+# creates it once (with placeholder values) and never overwrites it, and the
+# drift check ignores it. Fill in this repo's real values after the first sync.
+template: typo3-extension
+intentional-drift:
+  - .github/typo3-ci.json

--- a/.github/typo3-ci.json
+++ b/.github/typo3-ci.json
@@ -1,0 +1,7 @@
+{
+  "php-versions": ["8.2", "8.3", "8.4", "8.5"],
+  "typo3-versions": ["^13.4"],
+  "archive-prefix": "nr-textdb",
+  "package-name": "netresearch/nr-textdb",
+  "extension-key": "nr_textdb"
+}

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,7 +1,10 @@
 name: Auto-merge dependency PRs
 
 on:
-  pull_request:
+  # auto-merge only calls `gh pr merge` via the reusable with the base-repo
+  # token; it never checks out or runs PR head code, so pull_request_target
+  # (required for a write token on Dependabot/Renovate fork PRs) is safe here.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
 
 permissions: {}
 

--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -1,0 +1,18 @@
+name: Template Drift
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  drift:
+    uses: netresearch/.github/.github/workflows/check-template-drift.yml@main
+    with:
+      template: typo3-extension
+    permissions:
+      contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,46 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
+  # All extension-specific CI values (PHP/TYPO3 matrix + release metadata) live
+  # in .github/typo3-ci.json so THIS file stays byte-identical and
+  # drift-enforced across every typo3-extension. Customize them in
+  # typo3-ci.json (listed under intentional-drift in .github/template.yaml);
+  # do not edit this workflow.
+  config:
+    name: Resolve CI matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      php-versions: ${{ steps.matrix.outputs.php }}
+      typo3-versions: ${{ steps.matrix.outputs.typo3 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Read .github/typo3-ci.json
+        id: matrix
+        run: |
+          set -euo pipefail
+          f=.github/typo3-ci.json
+          {
+            echo "php=$(jq -c '."php-versions"' "$f")"
+            echo "typo3=$(jq -c '."typo3-versions"' "$f")"
+          } >> "$GITHUB_OUTPUT"
+
   ci:
+    needs: config
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
     with:
-        php-versions: '["8.2","8.3","8.4","8.5"]'
-        typo3-versions: '["^13.4"]'
+      php-versions: ${{ needs.config.outputs.php-versions }}
+      typo3-versions: ${{ needs.config.outputs.typo3-versions }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -5,7 +5,10 @@ on:
     - cron: '0 0 * * *'
   issues:
     types: [opened]
-  pull_request_target:
+  # greetings only posts a first-time contributor comment via the reusable; it
+  # never checks out or runs PR head code. pull_request_target is required to
+  # comment on fork PRs.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened]
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,45 @@ on:
 permissions: {}
 
 jobs:
+  # Per-extension release metadata (archive-prefix / package-name /
+  # extension-key) lives in .github/typo3-ci.json so THIS file stays
+  # byte-identical and drift-enforced. Customize them in typo3-ci.json
+  # (listed under intentional-drift in .github/template.yaml).
+  config:
+    name: Resolve release metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      archive-prefix: ${{ steps.meta.outputs.archive_prefix }}
+      package-name: ${{ steps.meta.outputs.package_name }}
+      extension-key: ${{ steps.meta.outputs.extension_key }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Read .github/typo3-ci.json
+        id: meta
+        run: |
+          set -euo pipefail
+          f=.github/typo3-ci.json
+          {
+            echo "archive_prefix=$(jq -r '."archive-prefix"' "$f")"
+            echo "package_name=$(jq -r '."package-name"' "$f")"
+            echo "extension_key=$(jq -r '."extension-key"' "$f")"
+          } >> "$GITHUB_OUTPUT"
+
   release:
+    needs: config
     uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
     permissions:
       contents: write
       id-token: write
       attestations: write
     with:
-      archive-prefix: nr-textdb
-      package-name: netresearch/nr-textdb
-      extension-key: nr_textdb
+      archive-prefix: ${{ needs.config.outputs.archive-prefix }}
+      package-name: ${{ needs.config.outputs.package-name }}
+      extension-key: ${{ needs.config.outputs.extension-key }}
     secrets:
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
Pilot migration to the canonical `typo3-extension` template (netresearch/.github). Explicit per-call-site permissions on every reusable call (no reliance on default_workflow_permissions), adds codeql + scorecard + check-template-drift. Per-repo matrix/release values live in `.github/typo3-ci.json` (intentional-drift); all workflows byte-identical to the template.