### PR TITLE
ci: migrate to split typo3-extension template

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -2,13 +2,14 @@
 # Drift from the template is blocking CI in this repo (check-template-drift.yml).
 # Record explicit exceptions under intentional-drift[] to unblock.
 #
-# All per-extension CI values (the PHP/TYPO3 test matrix and the release
-# metadata archive-prefix/package-name/extension-key) live in
-# `.github/typo3-ci.json`, NOT in the workflows — so ci.yml and release.yml
-# stay byte-identical and fully drift-enforced across every extension.
-# typo3-ci.json is listed under intentional-drift below: the template sync
-# creates it once (with placeholder values) and never overwrites it, and the
-# drift check ignores it. Fill in this repo's real values after the first sync.
+# Split-file model: the security/quality jobs (elevated permissions) live in the
+# byte-identical, drift-enforced checks.yml. The two files below are
+# per-extension and are NOT byte-governed:
+#   - .github/workflows/ci.yml      — the test matrix `with:` block (php/typo3
+#     versions, matrix-exclude, functional-tests, db, remove-dev-deps, coverage)
+#   - .github/workflows/release.yml — archive-prefix / package-name / extension-key
+# Customize those two in-repo; everything else stays in sync with the template.
 template: typo3-extension
 intentional-drift:
-  - .github/typo3-ci.json
+  - .github/workflows/ci.yml
+  - .github/workflows/release.yml

--- a/.github/typo3-ci.json
+++ b/.github/typo3-ci.json
@@ -1,7 +1,0 @@
-{
-  "php-versions": ["8.2", "8.3", "8.4", "8.5"],
-  "typo3-versions": ["^13.4"],
-  "archive-prefix": "nr-textdb",
-  "package-name": "netresearch/nr-textdb",
-  "extension-key": "nr_textdb"
-}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,70 @@
+name: Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: {}
+
+# Security + quality jobs with their explicit per-call-site permissions. This
+# file is byte-identical and drift-enforced across every typo3-extension — the
+# extension-specific test matrix lives in ci.yml (intentional-drift). Every
+# `uses:` job grants exactly the reusable's caller contract; no reliance on
+# default_workflow_permissions.
+jobs:
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
+  fuzz:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+    permissions:
+      contents: read
+
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+    permissions:
+      contents: read
+
+  codeql:
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+  scorecard:
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  pr-quality:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  labeler:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,95 +11,14 @@ on:
 permissions:
   contents: read
 
+# Per-extension test matrix (intentional-drift). Security/quality jobs are in checks.yml.
 jobs:
-  # All extension-specific CI values (PHP/TYPO3 matrix + release metadata) live
-  # in .github/typo3-ci.json so THIS file stays byte-identical and
-  # drift-enforced across every typo3-extension. Customize them in
-  # typo3-ci.json (listed under intentional-drift in .github/template.yaml);
-  # do not edit this workflow.
-  config:
-    name: Resolve CI matrix
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      php-versions: ${{ steps.matrix.outputs.php }}
-      typo3-versions: ${{ steps.matrix.outputs.typo3 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: Read .github/typo3-ci.json
-        id: matrix
-        run: |
-          set -euo pipefail
-          f=.github/typo3-ci.json
-          {
-            echo "php=$(jq -c '."php-versions"' "$f")"
-            echo "typo3=$(jq -c '."typo3-versions"' "$f")"
-          } >> "$GITHUB_OUTPUT"
-
   ci:
-    needs: config
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
     with:
-      php-versions: ${{ needs.config.outputs.php-versions }}
-      typo3-versions: ${{ needs.config.outputs.typo3-versions }}
+      php-versions: '["8.2","8.3","8.4","8.5"]'
+      typo3-versions: '["^13.4"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  security:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
-    permissions:
-      contents: read
-      security-events: write
-
-  fuzz:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
-    permissions:
-      contents: read
-
-  license-check:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
-    permissions:
-      contents: read
-
-  codeql:
-    uses: netresearch/.github/.github/workflows/codeql.yml@main
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-
-  scorecard:
-    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
-    uses: netresearch/.github/.github/workflows/scorecard.yml@main
-    permissions:
-      contents: read
-      security-events: write
-      id-token: write
-      actions: read
-
-  dependency-review:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
-    permissions:
-      contents: read
-      pull-requests: write
-
-  pr-quality:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
-    permissions:
-      contents: read
-      pull-requests: write
-
-  labeler:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@main
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,46 +7,19 @@ on:
 
 permissions: {}
 
+# The `with:` block (archive-prefix / package-name / extension-key) is
+# per-extension, so this file is listed under intentional-drift in
+# .github/template.yaml — set this repo's real values here.
 jobs:
-  # Per-extension release metadata (archive-prefix / package-name /
-  # extension-key) lives in .github/typo3-ci.json so THIS file stays
-  # byte-identical and drift-enforced. Customize them in typo3-ci.json
-  # (listed under intentional-drift in .github/template.yaml).
-  config:
-    name: Resolve release metadata
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      archive-prefix: ${{ steps.meta.outputs.archive_prefix }}
-      package-name: ${{ steps.meta.outputs.package_name }}
-      extension-key: ${{ steps.meta.outputs.extension_key }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: Read .github/typo3-ci.json
-        id: meta
-        run: |
-          set -euo pipefail
-          f=.github/typo3-ci.json
-          {
-            echo "archive_prefix=$(jq -r '."archive-prefix"' "$f")"
-            echo "package_name=$(jq -r '."package-name"' "$f")"
-            echo "extension_key=$(jq -r '."extension-key"' "$f")"
-          } >> "$GITHUB_OUTPUT"
-
   release:
-    needs: config
     uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
     permissions:
       contents: write
       id-token: write
       attestations: write
     with:
-      archive-prefix: ${{ needs.config.outputs.archive-prefix }}
-      package-name: ${{ needs.config.outputs.package-name }}
-      extension-key: ${{ needs.config.outputs.extension-key }}
+      archive-prefix: nr-textdb
+      package-name: netresearch/nr-textdb
+      extension-key: nr_textdb
     secrets:
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
Re-aligns with the split-file typo3-extension template (#191): test matrix in ci.yml (intentional-drift, ^13.4), security/quality jobs in byte-governed checks.yml, drops typo3-ci.json. The earlier pilot used the pre-split template and now drifts.