### PR TITLE
test: correct billion-laughs entity-expansion bound

### DIFF
--- a/Tests/Unit/Controller/TranslationControllerXXETest.php
+++ b/Tests/Unit/Controller/TranslationControllerXXETest.php
@@ -251,24 +251,24 @@ XML;
             LIBXML_NONET,
         );
 
-        // Parsing may succeed or fail - both are acceptable defensive outcomes
-        if ($data !== false) {
-            // If parsing succeeded, verify entity expansion is limited
-            $sourceValue = (string) $data->file->body->{'trans-unit'}->source;
+        // Parsing may succeed or fail - both are acceptable defensive outcomes.
+        // Measure the expanded source once (0 when parsing failed) so the single
+        // assertion below covers both outcomes without duplicate XML traversal.
+        $sourceLength = $data === false
+            ? 0
+            : strlen((string) $data->file->body->{'trans-unit'}->source);
 
-            // Entity expansion should be prevented or limited
-            // The source should not contain massively expanded "lol" strings
-            self::assertLessThan(
-                200,
-                strlen($sourceValue),
-                'Entity expansion should be prevented/limited to avoid DoS',
-            );
-        }
-
-        // Always perform an assertion: verify we either failed to parse OR content is limited
-        self::assertTrue(
-            $data === false || strlen((string) $data->file->body->{'trans-unit'}->source) < 200,
-            'Billion laughs attack was mitigated (parsing failed or expansion limited)',
+        // The mitigation that matters is the absence of *exponential* entity
+        // blowup (the classic billion-laughs DoS). This 2-level payload expands
+        // to at most 300 chars (&lol2; = 100x "lol") when libxml substitutes
+        // entities normally, which is harmless. A missing mitigation would
+        // instead produce a multi-megabyte explosion, so we assert the result
+        // stays within a small bound rather than pinning an exact length (which
+        // varies with the libxml version's entity-handling behaviour).
+        self::assertLessThan(
+            1000,
+            $sourceLength,
+            'Billion laughs mitigated: parsing failed or entity expansion stayed bounded (no exponential blowup)',
         );
     }
 


### PR DESCRIPTION
## Problem

The scheduled main CI run on 2026-06-29 failed in `TranslationControllerXXETest::billionLaughsAttackIsMitigated` ([run 385](https://github.com/netresearch/t3x-nr-textdb/actions/runs/28357129074)). The previous scheduled run (2026-06-22) was green on identical code — this is an **environment regression from a GitHub runner-image libxml update**, not a code regression.

```
Entity expansion should be prevented/limited to avoid DoS
Failed asserting that 300 is less than 200.
```

## Root cause

The test asserted the expanded `<source>` stays under **200** chars, but the 2-level payload (`&lol2;` = 100× "lol") legitimately expands to exactly **300** chars. Older libxml left the custom entity unexpanded (≈0 chars → passed); newer libxml substitutes it normally (300 chars → failed). No DoS occurred — the threshold was simply wrong by construction.

## Fix

The mitigation that matters is the absence of *exponential* entity blowup (the classic billion-laughs DoS), not an exact length. Assert the expansion stays within a small bound (**1000**) — well above this payload's 300-char legitimate full expansion, far below the multi-megabyte explosion a missing mitigation would produce.

## Verification

Local run (PHP 8.5.7, libxml current → expands to 300):
- `phpunit -c Build/UnitTests.xml` → **exit 0** (66 tests, was 1 failure)
- `composer ci:test:php:cgl` → exit 0
- PHPStan: changed file clean. (The 4 `InvocationStubber::with()` errors seen locally are a PHPUnit 13 vs CI dependency-resolution difference in unrelated test files; CI's PHPStan job is green.)