### PR TITLE
fix(rector): adopt the shared org rector config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,10 +73,3 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-
-  labeler:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@main
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+# pull_request_target is required: labeling fork PRs needs a write-scoped
+# token, which pull_request does not provide. The called reusable workflow
+# only runs actions/labeler (no checkout or execution of untrusted PR code),
+# so the usual pull_request_target risk does not apply here.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  labeler:
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -9,62 +9,26 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
-use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
-        __DIR__ . '/../Classes',
-        __DIR__ . '/../Configuration',
-        __DIR__ . '/../Resources',
-        __DIR__ . '/../ext_*.php',
-    ]);
+$configure = require __DIR__ . '/../.build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
-    $rectorConfig->skip([
-        __DIR__ . '/../ext_emconf.php',
-        __DIR__ . '/../ext_*.sql',
-    ]);
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: paths, code-quality sets, rule skips,
+    // and the package's ergebnis-free phpstan-rector.neon.
+    $configure($rectorConfig, __DIR__ . '/..');
 
-    // Rector loads PHPStan via its own bundled phar, which does not have
-    // ergebnis/phpstan-rules registered. Use a separate config that omits
-    // the `parameters.ergebnis` block to avoid a Nette schema validation
-    // error during type inference.
-    $rectorConfig->phpstanConfig('Build/phpstan-rector.neon');
-    $rectorConfig->importNames();
-    $rectorConfig->removeUnusedImports();
     $rectorConfig->disableParallel();
 
-    // Define what rule sets will be applied
     $rectorConfig->sets([
-        SetList::CODE_QUALITY,
-        SetList::CODING_STYLE,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::INSTANCEOF,
-        SetList::PRIVATIZATION,
-        SetList::STRICT_BOOLEANS,
-        SetList::TYPE_DECLARATION,
-        LevelSetList::UP_TO_PHP_82,
         Typo3LevelSetList::UP_TO_TYPO3_14,
     ]);
 
-    // Skip some rules
     $rectorConfig->skip([
-        CatchExceptionNameMatchingTypeRector::class,
-        ClassPropertyAssignToConstructorPromotionRector::class,
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
-        RemoveUselessVarTagRector::class,
-        RemoveUnusedPrivateMethodParameterRector::class,
+        __DIR__ . '/../ext_*.sql',
+
         // Extbase domain models are final, but their mapped properties MUST stay
         // `protected`: the DataMapper assigns them via
         // AbstractDomainObject::_setProperty() from the parent class scope, which

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -13,7 +13,7 @@ use Rector\Config\RectorConfig;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 
-$configure = require __DIR__ . '/../.build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+$configure = require_once __DIR__ . '/../.build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
 return static function (RectorConfig $rectorConfig) use ($configure): void {
     // Shared org base config: paths, code-quality sets, rule skips,


### PR DESCRIPTION
Rector 2.6.0 removed the deprecated `SetList::STRICT_BOOLEANS` this repo's bespoke `Build/rector.php` referenced, so the `ci / Rector` job fails on every PR since — including the template-sync PR #108, whose reruns could not recover because the repo does not consume the shared config that [typo3-ci-workflows#151](https://github.com/netresearch/typo3-ci-workflows/pull/151)/v1.3.3 fixed. Per org policy the org config defines the rule baseline, so instead of patching the bespoke copy this adopts the shared base config from `netresearch/typo3-ci-workflows`, keeping only the repo-specific parts (TYPO3 14 level set, `ext_*.sql` skip, `disableParallel()`, and the documented Extbase domain-model exemption for `PrivatizeFinalClassPropertyRector`). Verified with the CI-matched toolchain: rector fixpoint with zero code changes, CGL clean. Unblocks #108.