### PR TITLE
fix: scope import command to the requested extension key

### DIFF
--- a/Classes/Command/ImportCommand.php
+++ b/Classes/Command/ImportCommand.php
@@ -109,7 +109,7 @@ final class ImportCommand extends Command
             );
         } else {
             $this->extensions = [
-                $this->listUtility->getExtension($extensionKey),
+                $extensionKey => $this->listUtility->getExtension($extensionKey),
             ];
         }
 


### PR DESCRIPTION
## Problem

When an extension key is passed to `nr_textdb:import` (e.g. `nr_textdb:import my_ext`), the extension is stored in a numerically indexed array:

```php
$this->extensions = [
    $this->listUtility->getExtension($extensionKey),
];
```

`importTranslationsFromFiles()` then iterates with `array_keys($this->extensions)`, which yields the integer index `0` instead of the extension key. `ExtensionManagementUtility::extPath(0)` receives an `int` and throws a `TypeError`, so the scoped (per-extension) import fails entirely. Only the no-argument form (all extensions) works.

## Fix

Key the array by the extension key so `array_keys()` yields the key again:

```php
$this->extensions = [
    $extensionKey => $this->listUtility->getExtension($extensionKey),
];
```

Verified at runtime: `nr_textdb:import <ext>` now processes only the requested extension and imports/updates its labels correctly.

The same one-line fix applies to the other maintained branches (TYPO3-11, TYPO3_13, main); separate PRs follow for each.
