### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
         steps:
             -   id: checkout
                 name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
             -   id: setup_php
                 name: Set up PHP version ${{ matrix.php }}
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
                 with:
                     php-version: ${{ matrix.php }}
                     tools: composer:v2, php-cs-fixer
@@ -38,7 +38,7 @@ jobs:
 
             -   id: composer-cache-dependencies
                 name: Cache Composer dependencies
-                uses: actions/cache@v4
+                uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
                 with:
                     path: ${{ steps.composer-cache-vars.outputs.dir }}
                     key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.typo3 }}-${{ steps.composer-cache-vars.outputs.timestamp }}

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -14,7 +14,7 @@ jobs:
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Check tag
         run: |
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 7.4
           extensions: intl, mbstring, json, zip, curl


### PR DESCRIPTION
## Problem

The repository enforces that all GitHub Actions are pinned to a full-length commit SHA. The workflows on this branch still pin by tag, so every run fails at "Set up job":

```
The actions actions/checkout@v5, shivammathur/setup-php@v2, and actions/cache@v4 are not allowed ... because all actions must be pinned to a full-length commit SHA.
```

## Fix

Pin actions/checkout, shivammathur/setup-php and actions/cache to the commit their tags currently resolve to, in ci.yml and publish-to-ter.yml.
