### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -14,7 +14,7 @@ jobs:
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Check tag
         run: |
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 7.4
           extensions: intl, mbstring, json, zip, curl


### PR DESCRIPTION
## Problem

The repository enforces that all GitHub Actions are pinned to a full-length commit SHA. The workflows on this branch still pin by tag, so every run fails at "Set up job":

```
The actions actions/checkout@v5, shivammathur/setup-php@v2, and actions/cache@v4 are not allowed ... because all actions must be pinned to a full-length commit SHA.
```

## Fix

Pin actions/checkout, shivammathur/setup-php and actions/cache to the commit their tags currently resolve to, in ci.yml and publish-to-ter.yml.
