### PR TITLE
ci: drop removed Rector set SetList::STRICT_BOOLEANS

### DIFF
--- a/Build/rector.php
+++ b/Build/rector.php
@@ -51,7 +51,6 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::EARLY_RETURN,
         SetList::INSTANCEOF,
         SetList::PRIVATIZATION,
-        SetList::STRICT_BOOLEANS,
         SetList::TYPE_DECLARATION,
         LevelSetList::UP_TO_PHP_82,
         Typo3LevelSetList::UP_TO_TYPO3_13,


### PR DESCRIPTION
## Problem

The `ci / Rector` job fails on this branch:

```
[ERROR] Undefined constant Rector\Set\ValueObject\SetList::STRICT_BOOLEANS
```

Rector 2 (the version resolved in CI) removed the `SetList::STRICT_BOOLEANS` set, so `Build/rector.php` aborts while loading, before any code is analysed.

## Fix

Remove the `SetList::STRICT_BOOLEANS` reference so the Rector configuration loads again.
