### PR TITLE
fix(backend-module): normalize the module's filter config and pagination arguments

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -9,7 +9,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 2
+			count: 1
 			path: ../Classes/Controller/TranslationController.php
 
 		-

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -9,24 +9,12 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 4
-			path: ../Classes/Controller/TranslationController.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
 			count: 2
 			path: ../Classes/Controller/TranslationController.php
 
 		-
 			message: '#^Parameter \#2 \$settings of method Netresearch\\NrTextdb\\Controller\\TranslationController\:\:getPagination\(\) expects array\<string, bool\|int\>, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: ../Classes/Controller/TranslationController.php
-
-		-
-			message: '#^Method Netresearch\\NrTextdb\\Controller\\TranslationController\:\:getConfigFromBeUserData\(\) should return array\<string, int\|string\|null\> but returns array\<mixed\>\.$#'
-			identifier: return.type
 			count: 1
 			path: ../Classes/Controller/TranslationController.php
 

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -18,7 +18,7 @@ Backend implementation for editing TYPO3 translations. Architecture follows TYPO
 ## 2. Setup & environment
 
 **Prerequisites:**
-- PHP 8.1+ (extension requirements: ext-zip, ext-simplexml, ext-libxml)
+- PHP 8.2+ (extension requirements: ext-zip, ext-simplexml, ext-libxml, ext-mbstring)
 - TYPO3 13.4+
 - Composer 2.x
 

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -1051,7 +1051,7 @@ final class TranslationController extends ActionController
      * Applies default values if settings are not available:
      *
      * - pagination disabled
-     * - itemsPerPage = 10
+     * - itemsPerPage = 15
      *
      * @param QueryResultInterface<int, Translation> $items
      * @param array<string, int|bool>                $settings
@@ -1060,18 +1060,23 @@ final class TranslationController extends ActionController
      */
     private function getPagination(QueryResultInterface $items, array $settings): array
     {
+        // The paginator rejects anything below its first page with an exception,
+        // and an emptied page field of the pagination partial submits "".
         $currentPage = $this->request->hasArgument('currentPage')
-            ? (int) $this->request->getArgument('currentPage') : 1;
+            ? max(1, $this->normalizeRecordFilter($this->request->getArgument('currentPage')))
+            : 1;
+
+        $itemsPerPage = (int) ($settings['itemsPerPage'] ?? 15);
 
         if (
             array_key_exists('enablePagination', $settings)
             && ((bool) $settings['enablePagination'])
-            && ((int) $settings['itemsPerPage'] > 0)
+            && ($itemsPerPage > 0)
         ) {
             $paginator = new QueryResultPaginator(
                 $items,
                 $currentPage,
-                (int) ($settings['itemsPerPage'] ?? 15),
+                $itemsPerPage,
             );
 
             return [

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -11,7 +11,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrTextdb\Controller;
 
+use function is_numeric;
 use function is_string;
+use function max;
+use function mb_check_encoding;
 
 use Netresearch\NrTextdb\Domain\Model\Component;
 use Netresearch\NrTextdb\Domain\Model\Environment;
@@ -180,26 +183,29 @@ final class TranslationController extends ActionController
             );
         }
 
-        $config      = $this->getConfigFromBeUserData();
-        $componentId = (int) ($config['component'] ?? 0);
-        $typeId      = (int) ($config['type'] ?? 0);
-        $placeholder = is_string($config['placeholder']) ? $config['placeholder'] : null;
-        $value       = is_string($config['value']) ? $config['value'] : null;
+        [
+            'component'   => $componentId,
+            'type'        => $typeId,
+            'placeholder' => $placeholder,
+            'value'       => $value,
+        ] = $this->getConfigFromBeUserData();
 
+        // Backend module arguments arrive without a plugin namespace, so these are
+        // the raw query parameters and may carry any type, arrays included.
         if ($this->request->hasArgument('component')) {
-            $componentId = (int) $this->request->getArgument('component');
+            $componentId = $this->normalizeRecordFilter($this->request->getArgument('component'));
         }
 
         if ($this->request->hasArgument('type')) {
-            $typeId = (int) $this->request->getArgument('type');
+            $typeId = $this->normalizeRecordFilter($this->request->getArgument('type'));
         }
 
         if ($this->request->hasArgument('placeholder')) {
-            $placeholder = trim((string) $this->request->getArgument('placeholder'));
+            $placeholder = $this->normalizeTextFilter($this->request->getArgument('placeholder'));
         }
 
         if ($this->request->hasArgument('value')) {
-            $value = trim((string) $this->request->getArgument('value'));
+            $value = $this->normalizeTextFilter($this->request->getArgument('value'));
         }
 
         $defaultComponent   = $this->componentRepository->findByUid($componentId);
@@ -215,12 +221,14 @@ final class TranslationController extends ActionController
                 $value,
             );
 
-        $config['component']   = $componentId;
-        $config['type']        = $typeId;
-        $config['placeholder'] = $placeholder;
-        $config['value']       = $value;
-
-        $this->persistConfigInBeUserData($config);
+        $this->persistConfigInBeUserData(
+            [
+                'component'   => $componentId,
+                'type'        => $typeId,
+                'placeholder' => $placeholder,
+                'value'       => $value,
+            ],
+        );
 
         $this->moduleTemplate->assignMultiple([
             'defaultComponent'   => $defaultComponent,
@@ -440,10 +448,10 @@ final class TranslationController extends ActionController
             if ($language->getLanguageId() === 0) {
                 $translations = $this->translationRepository
                     ->findAllByComponentTypePlaceholderValueAndLanguage(
-                        (int) $component,
-                        (int) $type,
-                        is_string($placeholder) ? $placeholder : null,
-                        is_string($value) ? $value : null,
+                        $component,
+                        $type,
+                        $placeholder,
+                        $value,
                     );
 
                 $originals = $this->writeTranslationExportFile(
@@ -769,30 +777,81 @@ final class TranslationController extends ActionController
      *
      * The writer (persistConfigInBeUserData) emits JSON. The migration from
      * serialize()/unserialize() to json_encode/json_decode was declared a
-     * breaking change in commit e3e0334, so any legacy serialized payload
-     * is treated as invalid and discarded — the module simply rebuilds its
-     * filter config from defaults on the next request.
+     * breaking change in commit e3e0334. Any legacy serialized payload is
+     * treated as invalid and discarded. The module then rebuilds its filter
+     * config from the defaults on the next request.
      *
-     * @return array<string, int|string|null>
+     * The four filter keys are always present and always carry their declared
+     * type. exportAction() compares component and type with ===, so a missing
+     * or differently typed value would silently defeat its "no filter
+     * selected" guard. The stored payload cannot be trusted for that. It lives
+     * in be_users.uc, which a backend user can write through the usersettings
+     * endpoint of the core.
+     *
+     * @return array{component: int, type: int, placeholder: string|null, value: string|null}
      */
     private function getConfigFromBeUserData(): array
     {
         $storedConfig = $this->getBackendUser()
             ->getModuleData(self::class);
 
-        if (is_string($storedConfig) && $storedConfig !== '') {
-            $data = json_decode($storedConfig, true);
+        $data = (is_string($storedConfig) && ($storedConfig !== ''))
+            ? json_decode($storedConfig, true)
+            : null;
 
-            return is_array($data) ? $data : [];
+        if (!is_array($data)) {
+            $data = [];
         }
 
-        return [];
+        return [
+            'component'   => $this->normalizeRecordFilter($data['component'] ?? null),
+            'type'        => $this->normalizeRecordFilter($data['type'] ?? null),
+            'placeholder' => $this->normalizeTextFilter($data['placeholder'] ?? null),
+            'value'       => $this->normalizeTextFilter($data['value'] ?? null),
+        ];
+    }
+
+    /**
+     * Narrows an untrusted filter value to a record uid.
+     *
+     * Numeric input is coerced the way PHP does it, so "2" and 2.9 both become
+     * 2. Everything else, arrays and booleans included, becomes 0, and so does
+     * a negative number. Both the "no filter selected" guard of exportAction()
+     * and the repository read 0 as "this filter is not set".
+     */
+    private function normalizeRecordFilter(mixed $value): int
+    {
+        if (!is_numeric($value)) {
+            return 0;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    /**
+     * Narrows an untrusted filter value to a search term.
+     *
+     * The encoding check is what keeps listAction() alive. The term is written
+     * back with json_encode(), which throws on malformed UTF-8, and a query
+     * parameter carries arbitrary bytes.
+     */
+    private function normalizeTextFilter(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            return null;
+        }
+
+        return trim($value);
     }
 
     /**
      * Save current config in backend user settings.
      *
-     * @param array<string, int|string|null> $config
+     * @param array{component: int, type: int, placeholder: string|null, value: string|null} $config
      */
     private function persistConfigInBeUserData(array $config): void
     {

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -20,6 +20,7 @@ Minimum Requirements
    * ext-zip
    * ext-simplexml
    * ext-libxml
+   * ext-mbstring
 
 Recommended
 -----------
@@ -195,7 +196,7 @@ Import fails
 * Verify XLIFF file format matches expected structure
 * Check file permissions on upload
 * Review logs in **Admin Tools > Log**
-* Ensure PHP extensions (ext-zip, ext-simplexml, ext-libxml) are installed
+* Ensure PHP extensions (ext-zip, ext-simplexml, ext-libxml, ext-mbstring) are installed
 
 .. _uninstallation:
 

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -470,6 +470,36 @@ final class TranslationControllerTest extends FunctionalTestCase
     }
 
     /**
+     * @param string|string[] $currentPage
+     */
+    #[Test]
+    #[DataProvider('unusablePageNumberProvider')]
+    public function listingTheModuleSurvivesAnUnusablePageNumber(string|array $currentPage): void
+    {
+        // The page field of the pagination partial has no "required", and the
+        // core puts the emptied value straight into the navigation URL, so the
+        // list view is called with currentPage=. The paginator rejects everything
+        // below its first page with an exception.
+        $response = $this->dispatchModuleAction('list', ['currentPage' => $currentPage]);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * @return array<string, array{string|string[]}>
+     */
+    public static function unusablePageNumberProvider(): array
+    {
+        return [
+            'emptied field' => [''],
+            'zero'          => ['0'],
+            'negative'      => ['-1'],
+            'not a number'  => ['abc'],
+            'array'         => [['1']],
+        ];
+    }
+
+    /**
      * Runs one action of the backend module through the Extbase bootstrap.
      *
      * Calling the action on the controller instance directly skips

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -20,17 +20,25 @@ use Netresearch\NrTextdb\Service\ImportService;
 use Netresearch\NrTextdb\Service\TranslationService;
 use Override;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
+use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Configuration\SiteConfiguration;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Core\Bootstrap;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -61,6 +69,11 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  *   uid 8  pid 2       same placeholder on another page, must stay untouched
  *   uid 11 environment 2 same placeholder in another environment, likewise
  *
+ * The second group of tests covers the module's filter config. A backend user
+ * without a stored config used to receive an empty array. listAction() then
+ * logged "Undefined array key" for placeholder and value, and the "no filter
+ * selected" guard of exportAction() compared against null.
+ *
  * @see https://github.com/netresearch/t3x-nr-textdb/issues/100
  */
 #[CoversClass(TranslationController::class)]
@@ -85,6 +98,9 @@ final class TranslationControllerTest extends FunctionalTestCase
     ];
 
     protected bool $initializeDatabase = true;
+
+    private const FILTER_REQUIRED_MESSAGE
+        = 'Please select at least one type or component to create an export.';
 
     private TranslationController $controller;
 
@@ -116,7 +132,22 @@ final class TranslationControllerTest extends FunctionalTestCase
         // user has to be present for the queue to accept them.
         $this->setUpBackendUser(1);
 
+        // The module renders its messages through $GLOBALS['LANG'], which only
+        // the backend request handler sets up.
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)
+            ->createFromUserPreferences($GLOBALS['BE_USER']);
+
         $this->controller = $this->get(TranslationController::class);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        // Both are set per test and are not part of the state the testing
+        // framework restores.
+        unset($GLOBALS['LANG'], $GLOBALS['TYPO3_REQUEST']);
+
+        parent::tearDown();
     }
 
     #[Test]
@@ -158,7 +189,7 @@ final class TranslationControllerTest extends FunctionalTestCase
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
         self::assertSame('Second', $this->fetchValue(1));
-        self::assertSame([], $this->flashMessages(), 'A successful save must not queue an error message.');
+        self::assertSame([], $this->errorFlashMessages(), 'A successful save must not queue an error message.');
     }
 
     #[Test]
@@ -213,10 +244,335 @@ final class TranslationControllerTest extends FunctionalTestCase
 
         $controller->translateRecordAction(1, [0 => 'Send it']);
 
-        $messages = $this->flashMessages();
+        $messages = $this->errorFlashMessages();
 
         self::assertCount(1, $messages);
         self::assertStringContainsString('Duplicate entry', $messages[0]);
+    }
+
+    #[Test]
+    public function exportWithoutAStoredFilterIsRefused(): void
+    {
+        // A backend user that has never opened the module has no stored config.
+        // Reading it used to yield an empty array, which left the destructured
+        // component at null, and null === 0 never matched the guard below.
+        self::assertNull($GLOBALS['BE_USER']->getModuleData(TranslationController::class));
+
+        $response = $this->dispatchModuleAction('export');
+
+        self::assertSame(303, $response->getStatusCode());
+        self::assertStringContainsString('Translation/list', $response->getHeaderLine('Location'));
+        self::assertSame([self::FILTER_REQUIRED_MESSAGE], $this->errorFlashMessages());
+    }
+
+    #[Test]
+    public function exportWithAStoredFilterIsCarriedOut(): void
+    {
+        $this->writeSiteConfiguration();
+        $this->storeFilterConfig(['component' => 1]);
+
+        $response = $this->dispatchModuleAction('export');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/zip; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        self::assertStringStartsWith(
+            'PK',
+            (string) $response->getBody(),
+            'The response has to carry the archive itself, not just its headers.',
+        );
+        self::assertSame([], $this->errorFlashMessages());
+    }
+
+    #[Test]
+    public function exportWithAStoredTypeOnlyFilterIsCarriedOut(): void
+    {
+        // The export filters by component and type, and either one on its own is
+        // a filter. Only both being unset means "no filter selected".
+        $this->writeSiteConfiguration();
+        $this->storeFilterConfig(['type' => 2]);
+
+        $response = $this->dispatchModuleAction('export');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([], $this->errorFlashMessages());
+    }
+
+    #[Test]
+    public function listingTheModuleTruncatesAFractionalStoredFilter(): void
+    {
+        // The docblock of normalizeRecordFilter() promises PHP's own coercion,
+        // truncation rather than rejection, for numeric input that isn't an
+        // integer. "2" and 2.9 both become 2. listAction() is what reads,
+        // normalizes and writes the config back, exportAction() only reads it.
+        $this->storeFilterConfig(['component' => 2.9]);
+
+        $this->dispatchModuleAction('list');
+
+        self::assertSame(
+            ['component' => 2, 'type' => 0, 'placeholder' => null, 'value' => null],
+            $this->readStoredFilterConfig(),
+        );
+    }
+
+    /**
+     * @param string $storedConfig Raw payload, as it sits in be_users.uc
+     */
+    #[Test]
+    #[DataProvider('unusableStoredFilterProvider')]
+    public function exportWithAnUnusableStoredFilterIsRefused(string $storedConfig): void
+    {
+        // be_users.uc is writable by the backend user itself through the
+        // usersettings endpoint of the core, so none of these payloads is
+        // exotic. Each one has to end up as "no filter selected" rather than as
+        // a value that passes the guard and exports everything.
+        $GLOBALS['BE_USER']->pushModuleData(TranslationController::class, $storedConfig);
+
+        $response = $this->dispatchModuleAction('export');
+
+        self::assertSame(303, $response->getStatusCode());
+        self::assertSame([self::FILTER_REQUIRED_MESSAGE], $this->errorFlashMessages());
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function unusableStoredFilterProvider(): array
+    {
+        return [
+            'numeric string'     => ['{"component":"0","type":"0"}'],
+            'negative uid'       => ['{"component":-1,"type":-1}'],
+            'non numeric string' => ['{"component":"12abc","type":"none"}'],
+            'wrong value type'   => ['{"component":true,"type":{"uid":1}}'],
+            'legacy serialized'  => ['a:1:{s:9:"component";i:1;}'],
+            'json scalar'        => ['"component"'],
+        ];
+    }
+
+    #[Test]
+    public function exportWithStoredTextFiltersOfTheWrongTypeIsCarriedOut(): void
+    {
+        // The repository signature is (int, int, ?string, ?string), so an array
+        // or an int reaching it would be a TypeError under strict_types.
+        $this->writeSiteConfiguration();
+        $this->storeFilterConfig(
+            [
+                'component'   => 1,
+                'placeholder' => ['submit'],
+                'value'       => 42,
+            ],
+        );
+
+        $response = $this->dispatchModuleAction('export');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function listingTheModuleWithoutAStoredFilterEmitsNoWarning(): void
+    {
+        // The reported defect. listAction() read placeholder and value without a
+        // fallback and logged "Undefined array key" twice on the first request of
+        // every backend user. Warnings raised in Classes/ fail this suite, so the
+        // status code is only half of what this test asserts.
+        $response = $this->dispatchModuleAction('list');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function listingTheModuleStoresACompleteFilterConfig(): void
+    {
+        $this->dispatchModuleAction('list');
+
+        self::assertSame(
+            ['component' => 0, 'type' => 0, 'placeholder' => null, 'value' => null],
+            $this->readStoredFilterConfig(),
+        );
+    }
+
+    #[Test]
+    public function listingTheModuleKeepsTheStoredFilterAndAppliesIt(): void
+    {
+        // The whole point of the config: the filter of the editor survives the
+        // next call of the module, and it reaches the query. component and type
+        // are deliberately different values, so a swap of the two in the
+        // controller (a read or a write of the wrong argument) is observable.
+        $this->storeFilterConfig(['component' => 1, 'type' => 2]);
+
+        $response = $this->dispatchModuleAction('list');
+
+        self::assertSame(
+            ['component' => 1, 'type' => 2, 'placeholder' => null, 'value' => null],
+            $this->readStoredFilterConfig(),
+        );
+
+        // The row ids of the partial, because the placeholder "submit" also
+        // appears as the button type of the filter form in every request.
+        $body = (string) $response->getBody();
+
+        self::assertStringContainsString('id="entry-2"', $body, 'The filtered record has to be listed.');
+        self::assertStringNotContainsString(
+            'id="entry-1"',
+            $body,
+            'Record 1 shares the component and differs in the type, so it pins that operand.',
+        );
+        self::assertStringNotContainsString(
+            'id="entry-4"',
+            $body,
+            'Record 4 differs in both, so it pins the filter as a whole.',
+        );
+    }
+
+    #[Test]
+    public function listingTheModuleStoresTheSubmittedFilter(): void
+    {
+        // component and type are deliberately different, so a swap of the two
+        // arguments in the controller does not go unnoticed.
+        $this->dispatchModuleAction(
+            'list',
+            [
+                'component'   => '1',
+                'type'        => '2',
+                'placeholder' => ' submit ',
+                'value'       => ' Submit ',
+            ],
+        );
+
+        self::assertSame(
+            ['component' => 1, 'type' => 2, 'placeholder' => 'submit', 'value' => 'Submit'],
+            $this->readStoredFilterConfig(),
+        );
+    }
+
+    #[Test]
+    public function listingTheModuleDiscardsASubmittedFilterOfTheWrongType(): void
+    {
+        // Backend module arguments arrive as the raw query parameters, so a filter
+        // can be submitted as an array. Casting it used to raise an "Array to
+        // string conversion" warning for the text filter, and it silently turned
+        // the record filter into uid 1.
+        $this->dispatchModuleAction(
+            'list',
+            [
+                'component'   => ['1'],
+                'type'        => ['1'],
+                'placeholder' => ['submit'],
+                // A query parameter carries arbitrary bytes, and json_encode()
+                // throws on malformed UTF-8 when the config is written back.
+                'value' => "\x80",
+            ],
+        );
+
+        self::assertSame(
+            ['component' => 0, 'type' => 0, 'placeholder' => null, 'value' => null],
+            $this->readStoredFilterConfig(),
+        );
+    }
+
+    /**
+     * Runs one action of the backend module through the Extbase bootstrap.
+     *
+     * Calling the action on the controller instance directly skips
+     * ActionController::processRequest(), which is the only place that assigns
+     * $this->uriBuilder, so the export redirect dies before it is built. The
+     * route attribute is what BackendViewFactory and the Extbase request builder
+     * read the module and its controller from. The normalized parameters are
+     * what the page renderer of the module template resolves asset paths with.
+     *
+     * @param array<string, string|string[]> $queryParams Backend module arguments
+     *                                                    arrive without a plugin
+     *                                                    namespace
+     */
+    private function dispatchModuleAction(string $action, array $queryParams = []): ResponseInterface
+    {
+        $route = $this->get(Router::class)
+            ->getRoute('netresearch_textdb.Translation_' . $action);
+
+        $request = (new ServerRequest('https://example.com/typo3/module/netresearch/textdb', 'GET'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', $route)
+            ->withAttribute('module', $route->getOption('module'))
+            ->withQueryParams($queryParams);
+
+        $request = $request->withAttribute(
+            'normalizedParams',
+            NormalizedParams::createFromRequest($request),
+        );
+
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        return $this->get(Bootstrap::class)
+            ->handleBackendRequest($request);
+    }
+
+    /**
+     * Publishes a site with two languages.
+     *
+     * The export iterates the languages of the first site. Without one it
+     * produces no file at all. typo3/testing-framework 9 has no helper for this
+     * any more, and a SiteFinder mock via GeneralUtility::addInstance() does not
+     * work here either, because the controller is built by the container. The
+     * configuration is therefore written to the test instance, where tearDown()
+     * removes it again together with its cache.
+     */
+    private function writeSiteConfiguration(): void
+    {
+        $siteDirectory = Environment::getConfigPath() . '/sites/textdb';
+
+        if (!is_dir($siteDirectory) && !mkdir($siteDirectory, 0777, true) && !is_dir($siteDirectory)) {
+            self::fail('Could not create site directory ' . $siteDirectory);
+        }
+
+        $written = file_put_contents(
+            $siteDirectory . '/config.yaml',
+            <<<'YAML'
+                rootPageId: 1
+                base: 'https://example.com/'
+                languages:
+                  - languageId: 0
+                    title: English
+                    locale: en_US.UTF-8
+                    base: /
+                  - languageId: 1
+                    title: German
+                    locale: de_DE.UTF-8
+                    base: /de/
+                YAML,
+        );
+
+        self::assertNotFalse($written, 'Could not write the site configuration.');
+
+        // The site configuration is read through a cache that was already built.
+        $this->get(SiteConfiguration::class)->getAllExistingSites(false);
+    }
+
+    /**
+     * Writes a filter config the way the module itself does.
+     *
+     * @param array<string, float|int|string|string[]|null> $config
+     */
+    private function storeFilterConfig(array $config): void
+    {
+        $GLOBALS['BE_USER']->pushModuleData(
+            TranslationController::class,
+            json_encode($config, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    private function readStoredFilterConfig(): array
+    {
+        $rawConfig = $GLOBALS['BE_USER']->getModuleData(TranslationController::class);
+
+        self::assertIsString($rawConfig, 'The module did not store a filter config.');
+
+        $storedConfig = json_decode($rawConfig, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($storedConfig);
+
+        return $storedConfig;
     }
 
     /**
@@ -266,7 +622,7 @@ final class TranslationControllerTest extends FunctionalTestCase
      *
      * @return string[]
      */
-    private function flashMessages(): array
+    private function errorFlashMessages(): array
     {
         $messages = $this->get(FlashMessageService::class)
             ->getMessageQueueByIdentifier()

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "ext-zip": "*",
         "ext-simplexml": "*",
         "ext-libxml": "*",
+        "ext-mbstring": "*",
         "typo3/cms-core": "^13.4",
         "typo3/cms-backend": "^13.4",
         "typo3/cms-extbase": "^13.4",


### PR DESCRIPTION
## Problem

Backport of #130 to the TYPO3_13 line. A backend user without a stored module config received an empty array from `getConfigFromBeUserData()`. `listAction()` indexed `placeholder` and `value` directly and logged `Undefined array key` twice on the first request of every backend user. `exportAction()` destructured all four keys, so its "no filter selected" guard compared a null `component` against `0`, never matched, and let an unfiltered export through.

This branch had the same bug, byte-identical at the lines that matter, only shifted by five in the file.

## Fix

Same fix as #130. Neither source of that config is trustworthy. `be_users.uc` is writable by the backend user itself through the usersettings endpoint of the core, and a backend module reads its arguments as the raw query parameters, arrays included. Every filter is therefore narrowed to its declared type on the way in (`normalizeRecordFilter()`, `normalizeTextFilter()`). A stored `"0"` can no longer defeat the strict comparison in the guard, a submitted `placeholder[]` no longer raises an "Array to string conversion" warning, and a value that is not valid UTF-8 no longer takes down the whole list view when the config is written back with `json_encode()`.

A second commit guards the pagination arguments of the same list view. `currentPage` reached the paginator unchecked, and the page field of the pagination partial has no `required`, so an emptied field submits `currentPage=` and the paginator throws. `itemsPerPage` was read without a fallback in the condition and with one five lines below, so a TypoScript setup that enables pagination without setting the value silently disabled it.

## Tests

Twelve functional tests with twenty-one cases drive the real actions through the Extbase bootstrap. They cover the refused and the carried out export, a component-only and a type-only filter, six unusable stored payloads, a fractional stored component to pin the coercion `normalizeRecordFilter()` documents, what the list view stores for a submitted filter, that a stored filter survives the next call and reaches the query (component and type deliberately asymmetric, so a swap of the two doesn't go unnoticed), and five page-number inputs that used to misbehave.

## Verification

Verified with `composer ci:test` in a container matching this branch's PHP/TYPO3 matrix (phplint, phpstan level 10, rector, php-cs-fixer, unit and the relevant functional tests all green). Confirmed with a counter-check that the tests fail without the controller fix.

One item is documented but not covered by an automated test: the `itemsPerPage` fallback branch is unreachable through this extension's own TypoScript, which always ships both `enablePagination` and `itemsPerPage` together. Two attempts at a discriminating test (reflection on the private method, a runtime TypoScript override) didn't produce a reliable red/green signal, so it's documented in the commit message instead of tested.
