### PR TITLE
GH-134: Normalize the module's filter config and pagination arguments

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -24,8 +24,3 @@ parameters:
 			message: "#^Parameter \\#3 \\$type of method Netresearch\\\\NrTextdb\\\\Service\\\\TranslationService\\:\\:createTranslation\\(\\) expects Netresearch\\\\NrTextdb\\\\Domain\\\\Model\\\\Type, string given\\.$#"
 			count: 2
 			path: ../Classes/ViewHelpers/TranslateViewHelper.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: ../Tests/Unit/Controller/TranslationControllerTest.php

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -54,7 +54,13 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use ZipArchive;
 
+use function is_array;
+use function is_numeric;
 use function is_string;
+use function max;
+use function mb_check_encoding;
+use function trim;
+use function unserialize;
 
 /**
  * TranslationController.
@@ -212,26 +218,29 @@ class TranslationController extends ActionController
      */
     public function listAction(): ResponseInterface
     {
-        $config      = $this->getConfigFromBeUserData();
-        $componentId = $config['component'] ?? 0;
-        $typeId      = $config['type'] ?? 0;
-        $placeholder = $config['placeholder'] ?? null;
-        $value       = $config['value'] ?? null;
+        [
+            'component'   => $componentId,
+            'type'        => $typeId,
+            'placeholder' => $placeholder,
+            'value'       => $value,
+        ] = $this->getConfigFromBeUserData();
 
+        // Backend module arguments arrive without a plugin namespace, so these are
+        // the raw query parameters and may carry any type, arrays included.
         if ($this->request->hasArgument('component')) {
-            $componentId = (int) $this->request->getArgument('component');
+            $componentId = $this->normalizeRecordFilter($this->request->getArgument('component'));
         }
 
         if ($this->request->hasArgument('type')) {
-            $typeId = (int) $this->request->getArgument('type');
+            $typeId = $this->normalizeRecordFilter($this->request->getArgument('type'));
         }
 
         if ($this->request->hasArgument('placeholder')) {
-            $placeholder = trim((string) $this->request->getArgument('placeholder'));
+            $placeholder = $this->normalizeTextFilter($this->request->getArgument('placeholder'));
         }
 
         if ($this->request->hasArgument('value')) {
-            $value = trim((string) $this->request->getArgument('value'));
+            $value = $this->normalizeTextFilter($this->request->getArgument('value'));
         }
 
         $defaultComponent   = $this->componentRepository->findByUid($componentId);
@@ -247,12 +256,12 @@ class TranslationController extends ActionController
                 $value
             );
 
-        $config['component']   = $componentId;
-        $config['type']        = $typeId;
-        $config['placeholder'] = $placeholder;
-        $config['value']       = $value;
-
-        $this->persistConfigInBeUserData($config);
+        $this->persistConfigInBeUserData([
+            'component'   => $componentId,
+            'type'        => $typeId,
+            'placeholder' => $placeholder,
+            'value'       => $value,
+        ]);
 
         $this->view->assignMultiple([
             'defaultComponent'   => $defaultComponent,
@@ -411,8 +420,8 @@ class TranslationController extends ActionController
             if ($language->getLanguageId() === 0) {
                 $translations = $this->translationRepository
                     ->findAllByComponentTypePlaceholderValueAndLanguage(
-                        (int) $component,
-                        (int) $type,
+                        $component,
+                        $type,
                         $placeholder,
                         $value
                     );
@@ -708,32 +717,94 @@ class TranslationController extends ActionController
     /**
      * Get module config from user data.
      *
-     * @return array<array-key, int|string>
+     * The four filter keys are always present and always carry their declared
+     * type. exportAction() compares component and type with ===, so a missing
+     * or differently typed value would silently defeat its "no filter
+     * selected" guard. The stored payload cannot be trusted for that. It lives
+     * in be_users.uc, which a backend user can write through the usersettings
+     * endpoint of the core, and unserialize() on a payload that is not a valid
+     * serialized array does not return an array. A scalar result like false
+     * flows safely through the ?? below either way, but allowed_classes false
+     * turns any encoded object in the payload into a __PHP_Incomplete_Class
+     * instance instead, and indexing an object with [] throws an uncaught
+     * Error, not something ?? catches, which is what the is_array() check
+     * below actually guards against. allowed_classes is false for the same
+     * reason the core itself uses it on this exact kind of data
+     * (AbstractUserAuthentication::unpack_uc()): the payload is written by the
+     * backend user through the usersettings endpoint, so it is not just
+     * untrusted for its shape, unserialize() would otherwise instantiate and
+     * unserialize arbitrary classes from it before the array check below ever
+     * runs.
+     *
+     * @return array{component: int, type: int, placeholder: string|null, value: string|null}
      */
     private function getConfigFromBeUserData(): array
     {
         $serializedConfig = $this->getBackendUser()->getModuleData(static::class);
 
-        if (!is_string($serializedConfig)) {
-            return [];
+        $data = (is_string($serializedConfig) && ($serializedConfig !== ''))
+            ? unserialize(
+                $serializedConfig,
+                [
+                    'allowed_classes' => false,
+                ],
+            )
+            : null;
+
+        if (!is_array($data)) {
+            $data = [];
         }
 
-        if ($serializedConfig === '') {
-            return [];
+        return [
+            'component'   => $this->normalizeRecordFilter($data['component'] ?? null),
+            'type'        => $this->normalizeRecordFilter($data['type'] ?? null),
+            'placeholder' => $this->normalizeTextFilter($data['placeholder'] ?? null),
+            'value'       => $this->normalizeTextFilter($data['value'] ?? null),
+        ];
+    }
+
+    /**
+     * Narrows an untrusted filter value to a non-negative integer, 0 for
+     * anything that is not usable as one. Backend module arguments arrive as
+     * raw query parameters, so this also has to accept the numeric string a
+     * submitted filter actually is, not just int. Used both for the
+     * component/type record uid filters and, with an outer clamp to 1, for
+     * the pagination page number.
+     */
+    private function normalizeRecordFilter(mixed $value): int
+    {
+        if (!is_numeric($value)) {
+            return 0;
         }
 
-        return unserialize(
-            $serializedConfig,
-            [
-                'allowed_classes' => true,
-            ]
+        return max(
+            0,
+            (int) $value,
         );
+    }
+
+    /**
+     * Narrows an untrusted filter value to a search term.
+     */
+    private function normalizeTextFilter(mixed $value): ?string
+    {
+        if (
+            !is_string($value)
+            || !mb_check_encoding(
+                $value,
+                'UTF-8',
+            )
+        ) {
+            return null;
+        }
+
+        return trim($value);
     }
 
     /**
      * Save current config in backend user settings.
      *
-     * @param array<array-key, int|string> $config
+     * @param array{component: int, type: int, placeholder: string|null, value: string|null} $config
      */
     private function persistConfigInBeUserData(array $config): void
     {

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -970,26 +970,32 @@ class TranslationController extends ActionController
      * Applies default values if settings are not available:
      *
      * - pagination disabled
-     * - itemsPerPage = 10
+     * - itemsPerPage = 15
      *
      * @param QueryResultInterface    $items
      * @param array<string, int|bool> $settings
      *
-     * @return array<string, mixed>
+     * @return array{}|array{paginator: QueryResultPaginator, pagination: SimplePagination}
      */
     private function getPagination(QueryResultInterface $items, array $settings): array
     {
         $currentPage = $this->request->hasArgument('currentPage')
-            ? (int) $this->request->getArgument('currentPage') : 1;
+            ? max(
+                1,
+                $this->normalizeRecordFilter($this->request->getArgument('currentPage')),
+            )
+            : 1;
+
+        $itemsPerPage = (int) ($settings['itemsPerPage'] ?? 15);
 
         if (
             ($settings['enablePagination'] ?? false)
-            && ((int) $settings['itemsPerPage'] > 0)
+            && ($itemsPerPage > 0)
         ) {
             $paginator = new QueryResultPaginator(
                 $items,
                 $currentPage,
-                (int) ($settings['itemsPerPage'] ?? 15)
+                $itemsPerPage
             );
 
             return [

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -27,9 +27,12 @@ use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -748,6 +751,170 @@ final class TranslationControllerTest extends UnitTestCase
         );
     }
 
+    #[Test]
+    #[DataProvider('unusablePageNumberProvider')]
+    public function getPaginationClampsAnUnusablePageNumberToTheFirstPage(mixed $rawPage): void
+    {
+        $result = $this->invokeGetPagination(
+            $rawPage,
+            itemsPerPage: 15,
+        );
+
+        self::assertArrayHasKey(
+            'paginator',
+            $result,
+        );
+        self::assertSame(
+            1,
+            $result['paginator']->getCurrentPageNumber(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string|array<int, string>}>
+     */
+    public static function unusablePageNumberProvider(): array
+    {
+        return [
+            'zero'         => ['0'],
+            'negative'     => ['-1'],
+            'not a number' => ['abc'],
+            'emptied'      => [''],
+            'array'        => [['1']],
+        ];
+    }
+
+    #[Test]
+    public function getPaginationUsesTheRequestedPageNumber(): void
+    {
+        // 30 items at the default 15 per page is two pages, so page 2 is a
+        // real, reachable page, not one AbstractPaginator::updateInternalState()
+        // clamps back down to 1. Only getCurrentPageNumber() proves currentPage
+        // reaches the paginator at all, the normalizeRecordFilter() unit above
+        // only proves the value it computes, not that getPagination() passes
+        // it on.
+        $result = $this->invokeGetPagination(
+            '2',
+            itemsPerPage: 15,
+            totalItems: 30,
+        );
+
+        self::assertSame(
+            2,
+            $result['paginator']->getCurrentPageNumber(),
+        );
+    }
+
+    #[Test]
+    public function getPaginationUsesTheConfiguredItemsPerPage(): void
+    {
+        // 12 items at 5 per page is three pages. Every other test here either
+        // omits itemsPerPage or leaves it at the default 15, so this is the
+        // only one that proves a configured, non-default value reaches the
+        // paginator instead of being silently ignored.
+        $result = $this->invokeGetPagination(
+            '1',
+            itemsPerPage: 5,
+            totalItems: 12,
+        );
+
+        self::assertSame(
+            3,
+            $result['paginator']->getNumberOfPages(),
+        );
+    }
+
+    #[Test]
+    public function getPaginationUsesTheDocumentedDefaultItemsPerPageWhenTheSettingIsMissing(): void
+    {
+        // enablePagination without itemsPerPage is exactly what a site TypoScript
+        // override that only touches the former produces. The old code read
+        // itemsPerPage unguarded in the condition, which evaluated to 0 and
+        // silently disabled pagination instead of falling back to the default.
+        // 12 items split into pages of 15 is one page, split into pages of the
+        // stale PHPDoc default of 10 would be two, so the page count pins the
+        // fallback value itself, not just that pagination stayed on.
+        $result = $this->invokeGetPagination(
+            '1',
+            settings: ['enablePagination' => true],
+            totalItems: 12,
+        );
+
+        self::assertArrayHasKey(
+            'paginator',
+            $result,
+            'Pagination must not be silently disabled.',
+        );
+        self::assertSame(
+            1,
+            $result['paginator']->getNumberOfPages(),
+        );
+    }
+
+    #[Test]
+    public function getPaginationStaysDisabledWithoutEnablePagination(): void
+    {
+        $result = $this->invokeGetPagination(
+            '1',
+            settings: [],
+        );
+
+        self::assertSame(
+            [],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function getPaginationStaysDisabledWithAnItemsPerPageOfZero(): void
+    {
+        // itemsPerPage: 0 is a TypoScript misconfiguration, not an abstract
+        // case, and it used to reach QueryResultPaginator's constructor
+        // unchecked. AbstractPaginator::setItemsPerPage() throws
+        // InvalidArgumentException for anything below 1, so the >0 guard
+        // here is what turns that misconfiguration into pagination staying
+        // off instead of an HTTP 500.
+        $result = $this->invokeGetPagination(
+            '1',
+            itemsPerPage: 0,
+        );
+
+        self::assertSame(
+            [],
+            $result,
+        );
+    }
+
+    /**
+     * Invokes the private getPagination() with a real, minimally constructed
+     * Extbase request, the only property it reads besides its two parameters.
+     *
+     * @param array<string, bool|int>|null $settings
+     *
+     * @return array{}|array{paginator: QueryResultPaginator, pagination: SimplePagination}
+     */
+    private function invokeGetPagination(
+        mixed $rawPage,
+        ?int $itemsPerPage = null,
+        ?array $settings = null,
+        int $totalItems = 3,
+    ): array {
+        $this->wireControllerRequest(['currentPage' => $rawPage]);
+
+        $queryResult = self::createStub(QueryResultInterface::class);
+        $queryResult->method('count')->willReturn($totalItems);
+        $query = self::createStub(QueryInterface::class);
+        $query->method('setLimit')->willReturnSelf();
+        $query->method('setOffset')->willReturnSelf();
+        $query->method('execute')->willReturn($queryResult);
+        $queryResult->method('getQuery')->willReturn($query);
+
+        return $this->invokePrivateMethod(
+            'getPagination',
+            $queryResult,
+            $settings ?? ['enablePagination' => true, 'itemsPerPage' => $itemsPerPage],
+        );
+    }
 }
 
 /**

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -12,69 +12,756 @@ declare(strict_types=1);
 namespace Netresearch\NrTextdb\Tests\Unit\Controller;
 
 use Netresearch\NrTextdb\Controller\TranslationController;
+use Netresearch\NrTextdb\Domain\Repository\ComponentRepository;
 use Netresearch\NrTextdb\Domain\Repository\TranslationRepository;
+use Netresearch\NrTextdb\Domain\Repository\TypeRepository;
+use Netresearch\NrTextdb\Service\TranslationService;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use RuntimeException;
+use Throwable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
+use function glob;
+use function preg_match;
+use function rmdir;
+use function serialize;
+use function unserialize;
+
 /**
- * Test case.
+ * Regression tests for the module's filter config normalization.
  *
- * @author Thomas Schöne <thomas.schoene@netresearch.de>
+ * be_users.uc is writable by the backend user itself through the usersettings
+ * endpoint of the core, and a backend module reads its arguments as the raw
+ * query parameters, arrays included. getConfigFromBeUserData() used to return
+ * whatever was stored, unfiltered, and normalizeRecordFilter()/
+ * normalizeTextFilter() did not exist. Two defects followed from that:
+ *
+ *   1. On main and TYPO3_13, listAction() indexed placeholder/value directly
+ *      and logged "Undefined array key" for a backend user without a stored
+ *      config. On this branch that exact symptom never reproduced, both
+ *      already went through ??, but the underlying gap, no normalization on
+ *      the way in, is the same, see the TypeError and unusable-payload cases
+ *      below.
+ *   2. exportAction() destructured the empty array, component became null,
+ *      and null === 0 never matched its "no filter selected" guard, so the
+ *      export ran unfiltered.
+ *
+ * A third, more severe defect is specific to this branch and TYPO3-12 (both
+ * serialize the config with serialize()/unserialize() instead of main's and
+ * TYPO3_13's json_encode()/json_decode()): getConfigFromBeUserData() declares
+ * `: array`, but unserialize() on a payload that is not a valid serialized
+ * array returns false, not an array. array is a non-scalar type and is never
+ * coerced, so that is an uncaught TypeError regardless of strict_types.
+ *
+ * There is no functional test infrastructure on this branch (no
+ * FunctionalTests.xml, no AbstractFunctionalTestCase), so these are Unit
+ * tests. getConfigFromBeUserData() and the two normalizers have no I/O beyond
+ * $GLOBALS['BE_USER']->getModuleData(), which this double replaces with a
+ * plain array read, so testing them through reflection on a real controller
+ * instance is a faithful, side-effect-free reproduction of the actual code
+ * path, not a mock of the behaviour under test.
+ *
+ * @author Rico Sonntag <rico.sonntag@netresearch.de>
  */
 #[CoversClass(TranslationController::class)]
-#[UsesClass(TranslationRepository::class)]
-class TranslationControllerTest extends UnitTestCase
+final class TranslationControllerTest extends UnitTestCase
 {
-    /**
-     * @var TranslationController
-     */
-    protected TranslationController $subject;
+    private TranslationController $controller;
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->subject = $this->getMockBuilder(TranslationController::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->controller = (new ReflectionClass(TranslationController::class))
+            ->newInstanceWithoutConstructor();
+    }
+
+    #[Test]
+    public function getConfigFromBeUserDataReturnsTheDefaultsWithoutAStoredPayload(): void
+    {
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(null);
+
+        self::assertSame(
+            ['component' => 0, 'type' => 0, 'placeholder' => null, 'value' => null],
+            $this->readConfig(),
+        );
+    }
+
+    #[Test]
+    public function getConfigFromBeUserDataReturnsTheDefaultsForAMalformedSerializedPayload(): void
+    {
+        // unserialize() on this returns false, not an array. array is a
+        // non-scalar type and is never coerced, so the declared `: array`
+        // return type makes this an uncaught TypeError.
+        //
+        // unserialize() on genuinely malformed input also raises an E_NOTICE
+        // of its own, core's own AbstractUserAuthentication::unpack_uc()
+        // calls unserialize() the exact same unsuppressed way, not something
+        // this fix introduces. composer.json pins this branch to PHP ~8.1.0,
+        // where that is an E_NOTICE, not the E_WARNING it becomes on 8.3, and
+        // Build/UnitTests.xml only sets failOnWarning="true", not
+        // failOnNotice, so no local error handler is needed here.
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload('not valid serialized data');
+
+        self::assertSame(
+            ['component' => 0, 'type' => 0, 'placeholder' => null, 'value' => null],
+            $this->readConfig(),
+        );
+    }
+
+    #[Test]
+    public function getConfigFromBeUserDataKeepsAValidStoredPayload(): void
+    {
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(
+            serialize(['component' => 1, 'type' => 2, 'placeholder' => 'submit', 'value' => 'Submit']),
+        );
+
+        self::assertSame(
+            ['component' => 1, 'type' => 2, 'placeholder' => 'submit', 'value' => 'Submit'],
+            $this->readConfig(),
+        );
+    }
+
+    #[Test]
+    public function getConfigFromBeUserDataDoesNotInstantiateArbitraryClassesFromTheStoredPayload(): void
+    {
+        // be_users.uc is writable by the backend user itself through the
+        // usersettings endpoint, so a serialized payload naming an arbitrary
+        // class is attacker-reachable. With allowed_classes: true, unserialize()
+        // would build a real instance of that class and run its __wakeup()
+        // before is_array() below ever sees the result, that is the object
+        // injection this method's allowed_classes: false closes.
+        // WakeupProbe::$wasWoken only becomes true if PHP actually built an
+        // instance, so it is the one thing that tells the two settings apart,
+        // the returned array looks identical either way.
+        WakeupProbe::$wasWoken = false;
+
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(serialize(new WakeupProbe()));
+
+        self::assertSame(
+            ['component' => 0, 'type' => 0, 'placeholder' => null, 'value' => null],
+            $this->readConfig(),
+        );
+        self::assertFalse(
+            WakeupProbe::$wasWoken,
+            'unserialize() must not instantiate arbitrary classes from a user-writable payload.',
+        );
     }
 
     /**
-     * @test
+     * @param array<string, bool|int|string|array<string, int>> $storedPayload
      */
-    public function listActionFetchesAllTranslationsFromRepositoryAndAssignsThemToView(): void
+    #[Test]
+    #[DataProvider('unusableStoredFilterProvider')]
+    public function getConfigFromBeUserDataNormalizesAnUnusableStoredPayload(array $storedPayload): void
     {
-        self::markTestIncomplete('Rework');
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(serialize($storedPayload));
 
-        $allTranslations = $this->getMockBuilder(QueryResultInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $config = $this->readConfig();
 
-        $translationRepository = $this->getMockBuilder(TranslationRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        self::assertSame(
+            0,
+            $config['component'],
+        );
+        self::assertSame(
+            0,
+            $config['type'],
+        );
+    }
 
-        $translationRepository
-            ->expects(self::once())
-            ->method('getAllRecordsByIdentifier')
-            ->willReturn($allTranslations);
+    /**
+     * @return array<string, array{array<string, bool|int|string|array<string, int>>}>
+     */
+    public static function unusableStoredFilterProvider(): array
+    {
+        return [
+            'numeric string' => [['component' => '0', 'type' => '0']],
+            'negative uid'   => [['component' => -1, 'type' => -1]],
+            'non numeric'    => [['component' => '12abc', 'type' => 'none']],
+            'wrong type'     => [['component' => true, 'type' => ['uid' => 1]]],
+        ];
+    }
 
-        $this->inject($this->subject, 'translationRepository', $translationRepository);
+    #[Test]
+    public function normalizeRecordFilterTruncatesAFractionalValue(): void
+    {
+        // "2" and 2.9 both become 2, PHP's own coercion, not rejection.
+        self::assertSame(
+            2,
+            $this->invokeNormalizeRecordFilter(2.9),
+        );
+    }
 
-        $view = $this->getMockBuilder(\TYPO3Fluid\Fluid\View\ViewInterface::class)->getMock();
+    #[Test]
+    public function normalizeRecordFilterAcceptsTheNumericStringAQueryArgumentArrivesAs(): void
+    {
+        // Backend module arguments arrive as raw, unmapped query parameters, so
+        // this is the actual shape a submitted filter has, not the int cases
+        // above.
+        self::assertSame(
+            5,
+            $this->invokeNormalizeRecordFilter('5'),
+        );
+    }
 
-        $view
-            ->expects(self::once())
-            ->method('assign')
-            ->with('translations', $allTranslations);
+    #[Test]
+    #[DataProvider('unusableRecordFilterProvider')]
+    public function normalizeRecordFilterRejectsUnusableInput(mixed $value): void
+    {
+        self::assertSame(
+            0,
+            $this->invokeNormalizeRecordFilter($value),
+        );
+    }
 
-        $this->inject($this->subject, 'view', $view);
+    /**
+     * @return array<string, array{int|string|array<int, string>|bool|null}>
+     */
+    public static function unusableRecordFilterProvider(): array
+    {
+        return [
+            'negative'    => [-1],
+            'non numeric' => ['abc'],
+            'array'       => [['1']],
+            'bool'        => [true],
+            'null'        => [null],
+        ];
+    }
 
-        $this->subject->listAction();
+    #[Test]
+    public function normalizeTextFilterTrimsAValidString(): void
+    {
+        self::assertSame(
+            'submit',
+            $this->invokeNormalizeTextFilter(' submit '),
+        );
+    }
+
+    #[Test]
+    public function normalizeTextFilterRejectsMalformedUtf8(): void
+    {
+        // The term is written back with serialize(), which does not throw on
+        // malformed UTF-8, unlike main's json_encode(). The guard is kept for
+        // consistency and because listAction()/exportAction() may hand the
+        // value to output layers that do assume valid UTF-8.
+        self::assertNull($this->invokeNormalizeTextFilter("\x80"));
+    }
+
+    #[Test]
+    public function normalizeTextFilterRejectsANonString(): void
+    {
+        self::assertNull($this->invokeNormalizeTextFilter(['submit']));
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    private function readConfig(): array
+    {
+        return $this->invokePrivateMethod('getConfigFromBeUserData');
+    }
+
+    private function invokeNormalizeRecordFilter(mixed $value): int
+    {
+        return $this->invokePrivateMethod(
+            'normalizeRecordFilter',
+            $value,
+        );
+    }
+
+    private function invokeNormalizeTextFilter(mixed $value): ?string
+    {
+        return $this->invokePrivateMethod(
+            'normalizeTextFilter',
+            $value,
+        );
+    }
+
+    /**
+     * Invokes a private method of the controller under test via reflection.
+     */
+    private function invokePrivateMethod(string $method, mixed ...$arguments): mixed
+    {
+        return (new ReflectionMethod(
+            TranslationController::class,
+            $method,
+        ))->invoke(
+            $this->controller,
+            ...$arguments
+        );
+    }
+
+    /**
+     * A BackendUserAuthentication double whose getModuleData() reads the
+     * given raw payload, exactly as it would sit in be_users.uc. The parent
+     * implementation touches the user session (GeneralUtility::hmac(),
+     * $this->userSession), which is not set up in a Unit test and is not
+     * part of what these tests exercise.
+     */
+    private function backendUserWithStoredPayload(?string $payload): BackendUserAuthentication
+    {
+        return new class($payload) extends BackendUserAuthentication {
+            public function __construct(private readonly ?string $payload)
+            {
+                parent::__construct();
+            }
+
+            // Untyped, no return type, matching AbstractUserAuthentication's own
+            // signature on this branch's TYPO3 core exactly, PHP does not allow a
+            // child to add a parameter type the parent does not declare.
+            public function getModuleData($module, $type = ''): mixed
+            {
+                return $this->payload;
+            }
+        };
+    }
+
+    #[Test]
+    public function listActionNormalizesTheSubmittedFilterAndPersistsItUnderTheSameKeys(): void
+    {
+        // normalizeRecordFilter()/normalizeTextFilter()/persistConfigInBeUserData()
+        // are already pinned in isolation above, but listAction() is where
+        // they are actually wired together, and where the two historical
+        // defects in the class docblock lived: a raw (int) cast on the
+        // request argument instead of normalizeRecordFilter(), and the
+        // component/type keys of the persisted array being built by hand.
+        // component is negative on purpose, (int) '-3' stays -3 but
+        // normalizeRecordFilter('-3') clamps to 0, only the real wiring
+        // produces 0 here. component and type are also asymmetric, a swap of
+        // the persist wiring flips one against the other and this test would
+        // still pass with symmetric values. placeholder carries whitespace
+        // and value is malformed UTF-8, a raw pass-through would keep both
+        // as submitted, only normalizeTextFilter() trims the one and rejects
+        // the other, this is what actually proves those two request
+        // arguments are wired the same way component/type are, not just
+        // that the two isolated normalizer tests above hold.
+
+        // Inlined rather than built by a helper method: a helper typed to
+        // return BackendUserAuthentication would erase $pushedModuleData
+        // again below, the same reason backendUserWithStoredPayload() above
+        // is never read from outside its own getModuleData().
+        $backendUser = new class extends BackendUserAuthentication {
+            public ?string $pushedModuleData = null;
+
+            // Untyped, no return type, matching AbstractUserAuthentication's own
+            // signature on this branch's TYPO3 core exactly, PHP does not allow a
+            // child to add a parameter type the parent does not declare.
+            public function getModuleData($module, $type = ''): mixed
+            {
+                return null;
+            }
+
+            public function pushModuleData($module, $data, $noSave = 0): void
+            {
+                $this->pushedModuleData = $data;
+            }
+        };
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $capturedQueryArguments = $this->invokeListActionCapturingQueryArguments([
+            'component'   => '-3',
+            'type'        => '7',
+            'placeholder' => ' submit ',
+            'value'       => "\x80",
+        ]);
+
+        self::assertSame(
+            [0, 7, 'submit', null, 0],
+            $capturedQueryArguments,
+            'listAction() must pass the normalized filter to the repository query.',
+        );
+        self::assertSame(
+            ['component' => 0, 'type' => 7, 'placeholder' => 'submit', 'value' => null],
+            unserialize(
+                $backendUser->pushedModuleData,
+                ['allowed_classes' => false],
+            ),
+            'listAction() must persist the filter under the same keys it normalized them into.',
+        );
+    }
+
+    #[Test]
+    public function listActionUsesThePersistedFilterUnmodifiedWhenNoRequestArgumentsAreSubmitted(): void
+    {
+        // The destructuring assignment at the top of listAction() that reads
+        // getConfigFromBeUserData() is only ever overwritten by the four
+        // request-argument branches in the test above, never observed by
+        // itself, a key swap there (component/type) would be invisible to
+        // every other test, submitted arguments always win once present.
+        // This is the default landing-page case instead: a backend user
+        // returns with a persisted filter and submits no new one.
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(
+            serialize(['component' => 9, 'type' => 4, 'placeholder' => 'stored', 'value' => 'value']),
+        );
+
+        // persistConfigInBeUserData() re-persists the same, unmodified
+        // config right after the query, through the real
+        // BackendUserAuthentication::pushModuleData(), which touches an
+        // uninitialized user session on this reflection-constructed
+        // controller. The capture already ran by then, same reason the
+        // helper below catches Throwable rather than avoid it.
+        $capturedQueryArguments = $this->invokeListActionCapturingQueryArguments([]);
+
+        self::assertSame(
+            [9, 4, 'stored', 'value', 0],
+            $capturedQueryArguments,
+            'listAction() must use the persisted filter unmodified when no request arguments override it.',
+        );
+    }
+
+    private function setControllerProperty(string $name, object $value): void
+    {
+        $property = new ReflectionProperty(
+            TranslationController::class,
+            $name,
+        );
+        $property->setValue(
+            $this->controller,
+            $value,
+        );
+    }
+
+    /**
+     * Wires a real, minimally constructed Extbase request carrying the
+     * given arguments onto the controller. ActionController::$request is
+     * only ever assigned in processRequest(), which a Unit test does not
+     * run, so it is set directly via setControllerProperty() instead.
+     *
+     * @param array<string, mixed> $arguments
+     */
+    private function wireControllerRequest(array $arguments): void
+    {
+        $parameters    = (new ExtbaseRequestParameters())->setArguments($arguments);
+        $serverRequest = (new ServerRequest())->withAttribute(
+            'extbase',
+            $parameters,
+        );
+
+        $this->setControllerProperty(
+            'request',
+            new ExtbaseRequest($serverRequest),
+        );
+    }
+
+    /**
+     * Wires the given request arguments onto the controller for a
+     * listAction() call, stubs its repositories, invokes it, and returns
+     * what the repository query received. $this->view is never initialized
+     * outside processRequest(), which a Unit test does not run, so
+     * listAction() errors out once it reaches the view assignment, after
+     * both the query and the persisted-config write it is under test for.
+     * Caught as Throwable, not the more specific Error it actually is,
+     * because listAction() itself declares @throws InvalidQueryException,
+     * which keeps this catch block real from PHPStan's perspective too.
+     *
+     * @param array<string, string> $requestArguments
+     *
+     * @return array{int, int, string|null, string|null, int}|null
+     */
+    private function invokeListActionCapturingQueryArguments(array $requestArguments): ?array
+    {
+        $this->wireControllerRequest($requestArguments);
+
+        $pidProperty = new ReflectionProperty(
+            TranslationController::class,
+            'pid',
+        );
+        $pidProperty->setValue(
+            $this->controller,
+            1,
+        );
+
+        $capturedQueryArguments = null;
+        $translationRepository  = self::createStub(TranslationRepository::class);
+        $translationRepository->method('findAllByComponentTypePlaceholderValueAndLanguage')
+            ->willReturnCallback(static function (int $component, int $type, ?string $placeholder, ?string $value, int $languageId) use (&$capturedQueryArguments) {
+                $capturedQueryArguments = [$component, $type, $placeholder, $value, $languageId];
+
+                return self::createStub(QueryResultInterface::class);
+            });
+
+        $this->setControllerProperty(
+            'componentRepository',
+            self::createStub(ComponentRepository::class),
+        );
+        $this->setControllerProperty(
+            'typeRepository',
+            self::createStub(TypeRepository::class),
+        );
+        $this->setControllerProperty(
+            'translationRepository',
+            $translationRepository,
+        );
+
+        try {
+            $this->controller->listAction();
+        } catch (Throwable) {
+        }
+
+        return $capturedQueryArguments;
+    }
+
+    /**
+     * exportAction() creates its export directory before the filter guard
+     * ever runs, a real filesystem side effect of a Unit test, cleaned up
+     * here regardless of whether the guard blocked the call or let it
+     * through.
+     */
+    private function cleanupLeftoverExportDirectories(): void
+    {
+        $exportKeyPattern = '/^\/tmp\/[0-9a-f]{32}-textdb-export$/';
+
+        foreach (glob('/tmp/*-textdb-export') as $leftoverDirectory) {
+            if (preg_match(
+                $exportKeyPattern,
+                $leftoverDirectory,
+            ) === 1) {
+                rmdir($leftoverDirectory);
+            }
+        }
+    }
+
+    /**
+     * Runs exportAction() and asserts it throws the RuntimeException that
+     * the caller's translationService stub raises once getAllLanguages()
+     * runs, proving the filter guard let it that far without needing the
+     * full multi-language export/file-write pipeline that follows.
+     * exportAction() creates its export directory before the guard ever
+     * runs, a real filesystem side effect of a Unit test, cleaned up here.
+     */
+    private function expectExportActionToThrowPastTheGuard(): void
+    {
+        try {
+            $this->controller->exportAction();
+
+            self::fail('exportAction() should have thrown before reaching this point.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(
+                'reached past the filter guard',
+                $exception->getMessage(),
+            );
+        } finally {
+            $this->cleanupLeftoverExportDirectories();
+        }
+    }
+
+    #[Test]
+    public function exportActionDoesNotQueryTheRepositoryWithoutAFilter(): void
+    {
+        // The second historical defect this file's class docblock names:
+        // without a stored config, component/type used to come back as null,
+        // and null === 0 never matched this guard, so the export ran
+        // unfiltered instead of being blocked. getConfigFromBeUserData() now
+        // guarantees an int, this test is what actually proves the guard
+        // acts on that guarantee, not just that the guarantee itself holds.
+        // addFlashMessageToQueue() persists into the backend user's session,
+        // which the reflection-constructed controller and its double never
+        // set up, GeneralUtility::makeInstance(FlashMessageService::class)
+        // also stays a registered singleton past this test's lifetime.
+        $this->resetSingletonInstances = true;
+
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(null);
+        $GLOBALS['LANG']    = self::createStub(LanguageService::class);
+
+        // Stubbed and observed for its own sake, not just to avoid an
+        // unrelated crash: getAllLanguages() is the very next call after the
+        // guard, and translationService is otherwise a typed, uninitialized
+        // property. Without this stub, both the guard blocking correctly
+        // (an Error from addFlashMessageToQueue's session write) and the
+        // guard failing to block (an Error from the still-uninitialized
+        // translationService) land in the same catch block below, and
+        // $translationRepositoryCalled stays false either way, proving
+        // nothing. $translationServiceCalled is what actually tells the two
+        // apart.
+        $translationServiceCalled = false;
+        $translationService       = self::createStub(TranslationService::class);
+        $translationService->method('getAllLanguages')
+            ->willReturnCallback(static function () use (&$translationServiceCalled) {
+                $translationServiceCalled = true;
+
+                return [];
+            });
+        $this->setControllerProperty(
+            'translationService',
+            $translationService,
+        );
+
+        $translationRepositoryCalled = false;
+        $translationRepository       = self::createStub(TranslationRepository::class);
+        $translationRepository->method('findAllByComponentTypePlaceholderValueAndLanguage')
+            ->willReturnCallback(static function () use (&$translationRepositoryCalled) {
+                $translationRepositoryCalled = true;
+
+                return self::createStub(QueryResultInterface::class);
+            });
+        $this->setControllerProperty(
+            'translationRepository',
+            $translationRepository,
+        );
+
+        try {
+            // The flash message this guard queues tries to persist into the
+            // backend user's session, which does not exist on this double,
+            // same reason the listAction tests above catch Throwable.
+            $this->controller->exportAction();
+        } catch (Throwable) {
+        } finally {
+            $this->cleanupLeftoverExportDirectories();
+        }
+
+        self::assertFalse(
+            $translationServiceCalled,
+            'exportAction() must return before reaching the language loop when no filter is selected.',
+        );
+        self::assertFalse(
+            $translationRepositoryCalled,
+            'exportAction() must not query the repository when no filter is selected.',
+        );
+    }
+
+    #[Test]
+    public function exportActionProceedsPastTheGuardWithOnlyOneFilterSet(): void
+    {
+        // The guard is an &&, both component and type have to be unset for
+        // it to trigger. component is set here, type is not, on purpose: a
+        // guard weakened to || would treat this as "no filter" too and block
+        // it, exactly what the previous test cannot tell apart from the
+        // correct behaviour, since there both are 0. getAllLanguages() is
+        // the very next call after the guard, throwing from it and asserting
+        // that throw happened is a cheap way to prove the guard let this
+        // through without needing the full multi-language export/file-write
+        // pipeline that follows.
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(
+            serialize(['component' => 5, 'type' => 0, 'placeholder' => null, 'value' => null]),
+        );
+        // Only reached if the guard below is weakened to ||, addFlashMessageToQueue()
+        // would otherwise TypeError on a missing $GLOBALS['LANG'] instead of
+        // failing on the assertions this test is actually about.
+        $GLOBALS['LANG'] = self::createStub(LanguageService::class);
+
+        $translationService = self::createStub(TranslationService::class);
+        $translationService->method('getAllLanguages')
+            ->willThrowException(new RuntimeException('reached past the filter guard'));
+        $this->setControllerProperty(
+            'translationService',
+            $translationService,
+        );
+
+        $this->expectExportActionToThrowPastTheGuard();
+    }
+
+    #[Test]
+    public function exportActionProceedsPastTheGuardWithOnlyTypeSet(): void
+    {
+        // Mirrors the test above with component/type swapped: that one
+        // alone cannot tell a correct && apart from a guard that dropped
+        // type and checks component twice, ($component === 0) && ($component
+        // === 0), component being 0 here still trips such a mutant into
+        // blocking. type being the one and only filter set is what actually
+        // exercises the type half of the guard.
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(
+            serialize(['component' => 0, 'type' => 5, 'placeholder' => null, 'value' => null]),
+        );
+        $GLOBALS['LANG'] = self::createStub(LanguageService::class);
+
+        $translationService = self::createStub(TranslationService::class);
+        $translationService->method('getAllLanguages')
+            ->willThrowException(new RuntimeException('reached past the filter guard'));
+        $this->setControllerProperty(
+            'translationService',
+            $translationService,
+        );
+
+        $this->expectExportActionToThrowPastTheGuard();
+    }
+
+    #[Test]
+    public function exportActionUsesThePersistedFilterUnmodifiedInTheRepositoryQuery(): void
+    {
+        // Same reasoning as listActionUsesThePersistedFilterUnmodifiedWhenNoRequestArgumentsAreSubmitted():
+        // the destructuring assignment at the top of exportAction() is only
+        // ever read by the guard's === 0 comparisons, never by anything
+        // that observes the actual component/type/placeholder/value it
+        // produces, so a key swap there would pass every existing test.
+        // getAllLanguages() returns one language here instead of throwing,
+        // so the loop actually reaches the repository call this time, whose
+        // arguments are captured and then used to short-circuit before the
+        // real Zip/file-write pipeline.
+        $GLOBALS['BE_USER'] = $this->backendUserWithStoredPayload(
+            serialize(['component' => 9, 'type' => 4, 'placeholder' => 'stored', 'value' => 'value']),
+        );
+        $GLOBALS['LANG'] = self::createStub(LanguageService::class);
+
+        $language = self::createStub(SiteLanguage::class);
+        $language->method('getLanguageId')->willReturn(0);
+        $language->method('getTwoLetterIsoCode')->willReturn('en');
+
+        $translationService = self::createStub(TranslationService::class);
+        $translationService->method('getAllLanguages')->willReturn([$language]);
+        $this->setControllerProperty(
+            'translationService',
+            $translationService,
+        );
+
+        $capturedQueryArguments = null;
+        $translationRepository  = self::createStub(TranslationRepository::class);
+        $translationRepository->method('findAllByComponentTypePlaceholderValueAndLanguage')
+            ->willReturnCallback(static function (...$arguments) use (&$capturedQueryArguments) {
+                $capturedQueryArguments = $arguments;
+
+                throw new RuntimeException('reached the repository query');
+            });
+        $this->setControllerProperty(
+            'translationRepository',
+            $translationRepository,
+        );
+
+        try {
+            $this->controller->exportAction();
+
+            self::fail('exportAction() should have thrown before reaching this point.');
+        } catch (RuntimeException $exception) {
+            self::assertSame(
+                'reached the repository query',
+                $exception->getMessage(),
+            );
+        } finally {
+            $this->cleanupLeftoverExportDirectories();
+        }
+
+        self::assertSame(
+            [9, 4, 'stored', 'value', 0],
+            $capturedQueryArguments,
+            'exportAction() must use the persisted filter unmodified in the repository query.',
+        );
+    }
+
+}
+
+/**
+ * Exists only to make PHP object injection observable in a Unit test.
+ * $wasWoken becomes true only if unserialize() actually built an instance
+ * of this class from a serialized string, which is exactly what
+ * getConfigFromBeUserData()'s allowed_classes: false must prevent.
+ */
+final class WakeupProbe
+{
+    public static bool $wasWoken = false;
+
+    public function __wakeup(): void
+    {
+        self::$wasWoken = true;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     ],
     "require": {
         "php": "~8.1.0",
+        "ext-mbstring": "*",
         "ext-zip": "*",
         "ext-simplexml": "*",
         "ext-libxml": "*",


### PR DESCRIPTION
Refs #134

## Problem

Backport of #130/#131/#132 to the TYPO3-11 line. A backend user without a stored module config received an empty array from `getConfigFromBeUserData()`. `exportAction()` destructured all four keys, so its "no filter selected" guard compared a null `component` against `0`, never matched, and let an unfiltered export through.

Like TYPO3-12, this branch stores the module config with `serialize()`/`unserialize()` instead of `json_encode()`/`json_decode()`, so it also has the two more severe defects TYPO3-12 has: `getConfigFromBeUserData()` declares `: array`, but `unserialize()` on a payload that is not a valid serialized array returns `false`, not an array, an uncaught `TypeError` on every request to the module. The same payload was also a self-authenticated PHP object injection vector, `unserialize()` was called with `allowed_classes => true` on data the backend user can write through the usersettings endpoint.

## Fix

Same fix as #130, #131 and #132. Neither source of that config is trustworthy. Every filter is therefore narrowed to its declared type on the way in (`normalizeRecordFilter()`, `normalizeTextFilter()`). `allowed_classes` is now `false`, the same setting the core itself uses for this exact kind of data in `AbstractUserAuthentication::unpack_uc()`.

A second commit guards the pagination arguments of the same list view, same defect and fix as the other three branches.

This core's `AbstractUserAuthentication::getModuleData()`/`pushModuleData()` are untyped, unlike the other three branches, so the `BackendUserAuthentication` test doubles match that signature exactly. `composer.json` pins this branch to PHP `~8.1.0` only, so the malformed-payload test doesn't need the PHP-8.3-specific `set_error_handler()` workaround #132 needed.

## Tests

Same structure as #132: no functional test infrastructure on this branch, 48 Unit tests / 205 assertions drive the controller through reflection. `Build/phpstan-baseline.neon` drops its one entry for this test file (an ignored "Unreachable statement" from the old `markTestIncomplete()`-based stub this replaces).

## Verification

This branch has no CI workflow at all (only `publish-to-ter.yml`, no `ci.yml`), so nothing here has run in GitHub Actions before. Verified manually with `composer ci:test` in a container matching PHP `~8.1.0`: phplint, cgl and unit all green. Confirmed with a counter-check that 19 of the 24 new cases in the first commit error or fail against the unfixed controller.

Two things found while doing this, both pre-existing and out of scope for this fix, flagged here so they don't get mistaken for something this PR introduced:

- `phpstan analyze` fails on this branch with an internal error (`Class Netresearch\NrTextdb\Domain\Model\Abstract was not found while trying to analyse it`) while analysing `Classes/Service/ImportService.php`, reproduced identically on a pristine, unmodified checkout of this branch. `rector` hits the same underlying error. Scoped to just the two files this PR touches, `phpstan` runs clean except for two unrelated, pre-existing findings (missing generic type on `QueryResultInterface` in `writeTranslationExportFile()` and `getPagination()`), also reproduced on a pristine checkout.
- There is no `ci.yml` workflow on this branch, so none of the above has ever run automatically.
