### PR TITLE
fix(backend-module): validate translateRecordAction() request shape before persisting

### DIFF
--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -54,7 +54,6 @@ use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
@@ -428,12 +427,16 @@ final class TranslationController extends ActionController
             );
         }
 
-        return (new ForwardResponse('translated'))
-            ->withControllerName('Translation')
-            ->withExtensionName('NrTextdb')
-            ->withArguments([
-                'uid' => $parent,
-            ]);
+        // A redirect (not a forward) so the browser issues a fresh GET for the
+        // "translated" view. A forward keeps this same POST request active,
+        // and Fluid's form ViewHelpers repopulate a field from the request's
+        // own submitted value whenever the field name matches, even a
+        // rejected one, casting a rejected array value to a string to render
+        // it crashes the page with "Array to string conversion" although
+        // nothing was persisted.
+        return $this->redirectToUri(
+            $this->uriBuilder->reset()->uriFor('translated', ['uid' => $parent]),
+        );
     }
 
     /**

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Netresearch\NrTextdb\Controller;
 
 use function array_key_exists;
+use function in_array;
 use function is_int;
 use function is_numeric;
 use function is_string;
@@ -54,6 +55,7 @@ use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
@@ -77,6 +79,20 @@ use ZipArchive;
  */
 final class TranslationController extends ActionController
 {
+    /**
+     * The action names errorAction() is allowed to redirect back to. Kept
+     * in sync with Configuration/Backend/Modules.php's controllerActions.
+     *
+     * @var list<string>
+     */
+    private const KNOWN_REFERRER_ACTIONS = [
+        'list',
+        'translated',
+        'translateRecord',
+        'import',
+        'export',
+    ];
+
     private readonly ModuleTemplateFactory $moduleTemplateFactory;
 
     private ModuleTemplate $moduleTemplate;
@@ -279,6 +295,85 @@ final class TranslationController extends ActionController
         $this->moduleTemplate->assign('languages', $languages);
 
         return $this->moduleTemplate->renderResponse('Translation/Translated');
+    }
+
+    /**
+     * Extbase's default errorAction() forwards back to the referring action
+     * (e.g. "parent=abc" on translateRecord, which fails Extbase's own int
+     * property mapping before translateRecordAction() ever runs) via a
+     * ForwardResponse, which the Extbase Dispatcher intercepts and resolves
+     * internally by re-dispatching to the referring action within this same
+     * request/response. The browser never sees that as a separate
+     * navigation: the address bar and history entry stay on the failed
+     * request, so a page refresh would repeat it. This override redirects
+     * to the referring action instead, so the browser does a real, fresh
+     * GET navigation there.
+     */
+    protected function errorAction(): ResponseInterface
+    {
+        $forwardResponse = $this->forwardToReferringRequest();
+
+        if (!$forwardResponse instanceof ForwardResponse) {
+            return parent::errorAction();
+        }
+
+        // The referrer's HMAC scope is installation-global (TYPO3\CMS\
+        // Extbase\Security\HashScope), not bound to this extension or
+        // controller, so a validly signed __referrer can name any
+        // controller/action in the whole installation, including this
+        // controller's own non-routed errorAction() itself. Only fall
+        // through to an internal forward for a target this controller can
+        // actually, safely dispatch to, everything else gets a plain error
+        // response instead of risking an unresolvable forward (uncaught
+        // exception) or a forward back into errorAction() (infinite loop).
+        if (
+            ($forwardResponse->getControllerName() !== 'Translation')
+            || ($forwardResponse->getExtensionName() !== 'NrTextdb')
+            || !in_array(
+                $forwardResponse->getActionName(),
+                self::KNOWN_REFERRER_ACTIONS,
+                true,
+            )
+        ) {
+            return $this->htmlResponse($this->getFlattenedValidationErrorMessage())
+                ->withStatus(400);
+        }
+
+        // uriFor() silently returns an empty string when it cannot build a
+        // backend route for the given identifier (RouteNotFoundException
+        // swallowed internally), which would redirect to the site base
+        // instead of anywhere useful. In practice this cannot happen for
+        // the now known-safe, allowlisted target above, backend routes are
+        // static per action/controller with no parameters that could make
+        // an otherwise-registered one fail to resolve, this is defense in
+        // depth against that assumption ever changing. On the (expected to
+        // be unreachable) empty case, return the same plain error response
+        // as the allowlist check above rather than falling back to
+        // parent::errorAction(), which would re-forward with the same,
+        // still-unvalidated referrer.
+        $uri = $this->uriBuilder->reset()->uriFor(
+            $forwardResponse->getActionName(),
+            $forwardResponse->getArguments() ?? [],
+            $forwardResponse->getControllerName(),
+            $forwardResponse->getExtensionName(),
+        );
+
+        if ($uri === '') {
+            return $this->htmlResponse($this->getFlattenedValidationErrorMessage())
+                ->withStatus(400);
+        }
+
+        // addErrorFlashMessage() enqueues into a request-transient queue
+        // that only a same-request forward render would ever flush, a
+        // redirect ends the request without rendering it, so the message
+        // would be lost. addFlashMessageToQueue() persists it to the
+        // session-stored queue the module's chrome actually reads.
+        $this->addFlashMessageToQueue(
+            $this->translate('message.translation.save.title') ?? 'TextDb',
+            $this->translate('message.error.translation.request') ?? 'The submitted request could not be processed.',
+        );
+
+        return $this->redirectToUri($uri);
     }
 
     /**

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrTextdb\Controller;
 
+use function array_key_exists;
+use function is_int;
 use function is_numeric;
 use function is_string;
 use function max;
@@ -281,8 +283,12 @@ final class TranslationController extends ActionController
     }
 
     /**
-     * @param array<int<-1, max>, string> $new
-     * @param array<int, string>          $update
+     * $new and $update come straight from the request. Extbase's property
+     * mapping does not enforce the documented element shape at runtime, so
+     * both loops below validate keys and values before touching a record.
+     *
+     * @param array<array-key, string|array<array-key, string>> $new    Expected shape: array<int<-1, max>, string>
+     * @param array<array-key, string|array<array-key, string>> $update Expected shape: array<int, string>
      *
      * @throws IllegalObjectTypeException
      * @throws UnknownObjectException
@@ -290,31 +296,122 @@ final class TranslationController extends ActionController
     public function translateRecordAction(int $parent, array $new = [], array $update = []): ResponseInterface
     {
         $parentTranslation = $this->translationRepository->findRawByUid($parent);
+        $acceptedCount     = 0;
+        $rejectedCount     = 0;
 
         if ($parentTranslation instanceof Translation) {
+            // getAllLanguages() resolves the first configured site only (see
+            // TranslationService::getAllLanguages()), matching the languages
+            // translatedAction() renders as selectable. A language id that is
+            // only configured on another site in a multi-site installation is
+            // rejected here as well, same as it would be unreachable through
+            // the module's own "untranslated" list.
+            $allowedLanguages = $this->translationService->getAllLanguages();
+
             foreach ($new as $language => $value) {
-                $this->saveNewTranslation($parentTranslation, $language, trim($value));
+                if (
+                    !is_int($language)
+                    || ($language < -1)
+                    || !is_string($value)
+                    || !array_key_exists($language, $allowedLanguages)
+                ) {
+                    ++$rejectedCount;
+
+                    continue;
+                }
+
+                $trimmedValue = trim($value);
+
+                if ($trimmedValue === '') {
+                    // An untouched textarea: not a rejection and not a saved
+                    // entry either, it updates neither counter. If it is the
+                    // only thing submitted, $nothingWasSaved still applies
+                    // below.
+                    continue;
+                }
+
+                if ($this->saveNewTranslation($parentTranslation, $language, $trimmedValue)) {
+                    ++$acceptedCount;
+                } else {
+                    ++$rejectedCount;
+                }
+            }
+        } else {
+            // A well-formed, blank entry is the only shape the parent-exists
+            // branch above does not count as a rejection either (it is
+            // silently skipped). Everything else, including a malformed
+            // value, counts as payload here too.
+            $newHasPayload = array_filter(
+                $new,
+                static fn (string|array $value): bool => !is_string($value) || (trim($value) !== ''),
+            ) !== [];
+
+            if ($newHasPayload) {
+                // $parent does not resolve to a record (tampered or stale
+                // value), so a submitted new[] payload is unreachable. Count
+                // it once instead of dropping it without any signal, the
+                // individual entries were never validated far enough to
+                // count them apart.
+                ++$rejectedCount;
             }
         }
 
         foreach ($update as $translationUid => $value) {
+            if (
+                !is_int($translationUid)
+                // A non-positive uid can never match a record. Rejecting it
+                // here avoids a pointless lookup.
+                || ($translationUid <= 0)
+                || !is_string($value)
+            ) {
+                ++$rejectedCount;
+
+                continue;
+            }
+
             $translation = $this->translationRepository->findRawByUid($translationUid);
 
             if ($translation instanceof Translation) {
                 $translation->setValue(trim($value));
 
                 $this->translationRepository->update($translation);
+                ++$acceptedCount;
+            } else {
+                // A well-formed but non-existent uid (deleted between page
+                // load and submit, or a tampered value) must count as
+                // rejected too, or it is dropped without any signal.
+                ++$rejectedCount;
             }
         }
+
+        // A real dialog submission always carries at least one valid update[]
+        // entry (the record itself, echoed back), so a plain "was anything
+        // rejected" flag would rarely fire from the UI and a tampered/invalid
+        // entry submitted alongside a normal save would be dropped silently.
+        // The two conditions below are independent and both flash messages
+        // can appear together, so a partially rejected submission is never
+        // reported as an unqualified success.
+        $nothingWasSaved   = (($new !== []) || ($update !== [])) && ($acceptedCount === 0);
+        $somethingRejected = $rejectedCount > 0;
 
         try {
             $this->persistenceManager->persistAll();
 
-            $this->addFlashMessageToQueue(
-                $this->translate('message.translation.save.title') ?? 'TextDb',
-                $this->translate('message.translation.saved') ?? 'The translation was saved.',
-                ContextualFeedbackSeverity::OK,
-            );
+            if ($nothingWasSaved || $somethingRejected) {
+                $this->addFlashMessageToQueue(
+                    $this->translate('message.translation.save.title') ?? 'TextDb',
+                    $this->translate('message.translation.rejected') ?? 'One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.',
+                    ContextualFeedbackSeverity::WARNING,
+                );
+            }
+
+            if ($acceptedCount > 0) {
+                $this->addFlashMessageToQueue(
+                    $this->translate('message.translation.save.title') ?? 'TextDb',
+                    $this->translate('message.translation.saved') ?? 'The translation was saved.',
+                    ContextualFeedbackSeverity::OK,
+                );
+            }
         } catch (Throwable $throwable) {
             // Without this guard a persistence error (historically a collision
             // with the unique key on the translation table) escaped the module
@@ -350,20 +447,23 @@ final class TranslationController extends ActionController
      * misses rows that do exist. Blindly adding a record for each entry
      * therefore produced empty rows and, on the second save, a collision with
      * the unique key (sys_language_uid, pid, environment, component, type,
-     * placeholder, deleted). Skipping empties and updating an existing record
-     * makes that collision impossible by construction. See issue #100.
+     * placeholder, deleted). Updating an existing record instead of adding a
+     * new one makes that collision impossible by construction. See issue
+     * #100. The caller is expected to have already skipped blank values, an
+     * untouched textarea is not a rejection and must not reach this method.
      *
-     * @param int<-1, max> $language
+     * @param int<-1, max>     $language
+     * @param non-empty-string $value
+     *
+     * @return bool TRUE if a record was added or updated, FALSE if the parent
+     *              translation was missing its environment/component/type
+     *              and nothing could be saved
      *
      * @throws IllegalObjectTypeException
      * @throws UnknownObjectException
      */
-    private function saveNewTranslation(Translation $parentTranslation, int $language, string $value): void
+    private function saveNewTranslation(Translation $parentTranslation, int $language, string $value): bool
     {
-        if ($value === '') {
-            return;
-        }
-
         $environment = $parentTranslation->getEnvironment();
         $component   = $parentTranslation->getComponent();
         $type        = $parentTranslation->getType();
@@ -383,7 +483,7 @@ final class TranslationController extends ActionController
 
             $this->translationRepository->update($existingTranslation);
 
-            return;
+            return true;
         }
 
         $translation = $this->translationService
@@ -395,7 +495,11 @@ final class TranslationController extends ActionController
 
         if ($translation instanceof Translation) {
             $this->translationRepository->add($translation);
+
+            return true;
         }
+
+        return false;
     }
 
     /**

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Netresearch\NrTextdb\Controller;
 
 use function array_key_exists;
-use function in_array;
 use function is_int;
 use function is_numeric;
 use function is_string;
@@ -79,20 +78,6 @@ use ZipArchive;
  */
 final class TranslationController extends ActionController
 {
-    /**
-     * The action names errorAction() is allowed to redirect back to. Kept
-     * in sync with Configuration/Backend/Modules.php's controllerActions.
-     *
-     * @var list<string>
-     */
-    private const KNOWN_REFERRER_ACTIONS = [
-        'list',
-        'translated',
-        'translateRecord',
-        'import',
-        'export',
-    ];
-
     private readonly ModuleTemplateFactory $moduleTemplateFactory;
 
     private ModuleTemplate $moduleTemplate;
@@ -299,15 +284,9 @@ final class TranslationController extends ActionController
 
     /**
      * Extbase's default errorAction() forwards back to the referring action
-     * (e.g. "parent=abc" on translateRecord, which fails Extbase's own int
-     * property mapping before translateRecordAction() ever runs) via a
-     * ForwardResponse, which the Extbase Dispatcher intercepts and resolves
-     * internally by re-dispatching to the referring action within this same
-     * request/response. The browser never sees that as a separate
-     * navigation: the address bar and history entry stay on the failed
-     * request, so a page refresh would repeat it. This override redirects
-     * to the referring action instead, so the browser does a real, fresh
-     * GET navigation there.
+     * within the same request/response, so the browser never sees a real
+     * navigation and a refresh would repeat the failed request. This
+     * redirects there instead.
      */
     protected function errorAction(): ResponseInterface
     {
@@ -317,40 +296,17 @@ final class TranslationController extends ActionController
             return parent::errorAction();
         }
 
-        // The referrer's HMAC scope is installation-global (TYPO3\CMS\
-        // Extbase\Security\HashScope), not bound to this extension or
-        // controller, so a validly signed __referrer can name any
-        // controller/action in the whole installation, including this
-        // controller's own non-routed errorAction() itself. Only fall
-        // through to an internal forward for a target this controller can
-        // actually, safely dispatch to, everything else gets a plain error
-        // response instead of risking an unresolvable forward (uncaught
-        // exception) or a forward back into errorAction() (infinite loop).
-        if (
-            ($forwardResponse->getControllerName() !== 'Translation')
-            || ($forwardResponse->getExtensionName() !== 'NrTextdb')
-            || !in_array(
-                $forwardResponse->getActionName(),
-                self::KNOWN_REFERRER_ACTIONS,
-                true,
-            )
-        ) {
+        // The referrer's HMAC scope is installation-global, not bound to
+        // this extension, but uriFor() builds the route from this
+        // request's own module identifier, so a foreign controller/action
+        // can never resolve outside this module's five routes (empty $uri
+        // below). extensionName is the one value backend routing ignores,
+        // so it needs this explicit check.
+        if ($forwardResponse->getExtensionName() !== 'NrTextdb') {
             return $this->htmlResponse($this->getFlattenedValidationErrorMessage())
                 ->withStatus(400);
         }
 
-        // uriFor() silently returns an empty string when it cannot build a
-        // backend route for the given identifier (RouteNotFoundException
-        // swallowed internally), which would redirect to the site base
-        // instead of anywhere useful. In practice this cannot happen for
-        // the now known-safe, allowlisted target above, backend routes are
-        // static per action/controller with no parameters that could make
-        // an otherwise-registered one fail to resolve, this is defense in
-        // depth against that assumption ever changing. On the (expected to
-        // be unreachable) empty case, return the same plain error response
-        // as the allowlist check above rather than falling back to
-        // parent::errorAction(), which would re-forward with the same,
-        // still-unvalidated referrer.
         $uri = $this->uriBuilder->reset()->uriFor(
             $forwardResponse->getActionName(),
             $forwardResponse->getArguments() ?? [],

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -177,7 +177,11 @@
       </trans-unit>
       <trans-unit id="message.translation.saved">
         <source>The translation was saved.</source>
-        <target state="needs-translation">The translation was saved.</target>
+        <target state="final">Die Übersetzung wurde gespeichert.</target>
+      </trans-unit>
+      <trans-unit id="message.translation.rejected">
+        <source>One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.</source>
+        <target state="final">Eine oder mehrere der übermittelten Übersetzungen konnten nicht gespeichert werden. Der Datensatz, die Zielsprache oder der übermittelte Wert war ungültig.</target>
       </trans-unit>
       <trans-unit id="message.translation.save.title" translate="no">
         <source>TextDb</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -191,6 +191,10 @@
         <source>The translation could not be saved: %s</source>
         <target state="needs-translation">The translation could not be saved: %s</target>
       </trans-unit>
+      <trans-unit id="message.error.translation.request">
+        <source>The submitted request could not be processed.</source>
+        <target state="final">Die übermittelte Anfrage konnte nicht verarbeitet werden.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -145,6 +145,9 @@
             <trans-unit id="message.error.translation.save">
                 <source>The translation could not be saved: %s</source>
             </trans-unit>
+            <trans-unit id="message.error.translation.request">
+                <source>The submitted request could not be processed.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -136,6 +136,9 @@
             <trans-unit id="message.translation.saved">
                 <source>The translation was saved.</source>
             </trans-unit>
+            <trans-unit id="message.translation.rejected">
+                <source>One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.</source>
+            </trans-unit>
             <trans-unit id="message.translation.save.title" translate="no">
                 <source>TextDb</source>
             </trans-unit>

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -42,7 +42,6 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Core\Bootstrap;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
@@ -667,16 +666,19 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    public function translateRecordThroughTheRouteRejectsAReferrerTargetingAnUnregisteredAction(): void
+    public function translateRecordThroughTheRouteRejectsAReferrerTargetingAnUnroutableAction(): void
     {
         // The referrer HMAC scope is installation-global, not bound to this
         // module, so a validly signed __referrer can name any action,
         // including one that does not exist as a method at all, or this
-        // controller's own non-routed errorAction() itself (which would
-        // forward back into errorAction() again, an infinite loop). The
-        // errorAction() override only forwards to an allowlisted, known-
-        // safe action, so a target outside that list gets a plain error
-        // response instead of ever attempting an internal forward.
+        // controller's own non-routed errorAction() itself. Neither is a
+        // registered route under this module (Configuration/Backend/
+        // Modules.php's controllerActions), so uriFor() cannot build a URI
+        // for it (mutation-verified: an actual allowlist of action names
+        // added ahead of this test did not change its outcome, uriFor()'s
+        // own route lookup already rejects it), and errorAction() falls
+        // through to a plain error response instead of ever redirecting
+        // anywhere.
         $response = $this->dispatchTranslateRecord([
             'parent'     => 'abc',
             '__referrer' => $this->buildSignedReferrer('notARegisteredAction'),
@@ -686,14 +688,16 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    public function translateRecordThroughTheRouteRejectsAReferrerFromAForeignController(): void
+    public function translateRecordThroughTheRouteRejectsAReferrerFromAnUnroutableForeignController(): void
     {
         // Same installation-global HMAC scope as above, but here the
         // referrer names a real, routable action, just on a different
         // controller (as any other Extbase backend module's own form would
-        // sign). Without the controller-name check, this would pass the
-        // action-name allowlist and forward into a controller this module
-        // was never meant to dispatch to.
+        // sign). "SomeOtherController_list" is not a route this module
+        // registers either, so this hits the exact same uriFor() rejection
+        // as the unroutable-action case above, not a dedicated controller
+        // check (mutation-verified, this test still passes with no
+        // controller-name check present at all).
         $response = $this->dispatchTranslateRecord([
             'parent'     => 'abc',
             '__referrer' => $this->buildSignedReferrer('list', 'SomeOtherController'),
@@ -705,44 +709,24 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function translateRecordThroughTheRouteRejectsAReferrerFromAForeignExtension(): void
     {
-        // Same as the foreign-controller case above, but with a matching
-        // controller/action name from a different extension entirely
-        // ('Translation'/'list' happens to also be a plausible controller/
-        // action pair elsewhere), so only the extension-name check catches
-        // it.
+        // Same as the two cases above, but with a matching controller/
+        // action pair from a different extension entirely ('Translation'/
+        // 'list' happens to also be a plausible controller/action pair
+        // elsewhere). uriFor()'s backend routing builds its route
+        // identifier from THIS request's own module, not the referrer, and
+        // never consults extensionName at all, so unlike the two cases
+        // above, this one WOULD build a valid URI for this module's own
+        // Translation/list route (silently honouring a foreign referrer
+        // onto our own module, not redirecting to the foreign extension
+        // itself) and 303 there without errorAction()'s explicit
+        // extensionName check (mutation-verified, removing that check
+        // turns this into a 303).
         $response = $this->dispatchTranslateRecord([
             'parent'     => 'abc',
             '__referrer' => $this->buildSignedReferrer('list', 'Translation', 'SomeOtherExtension'),
         ]);
 
         self::assertSame(400, $response->getStatusCode());
-    }
-
-    #[Test]
-    public function knownReferrerActionsMatchesTheModuleConfig(): void
-    {
-        // errorAction()'s KNOWN_REFERRER_ACTIONS allowlist is what makes
-        // its uriFor() call provably safe (a static, parameter-less backend
-        // route for controller "Translation" plus one of these actions
-        // always resolves), but that safety only holds as long as the list
-        // does not drift ahead of what is actually registered. If an
-        // action were ever removed from Configuration/Backend/Modules.php
-        // without also being removed here, the allowlist would let it
-        // through and uriFor() would fail to resolve it after all.
-        // require_once would return true instead of the array here, this
-        // file is already loaded once by TYPO3's own bootstrap by the time
-        // this test runs, and the return value is what this test needs.
-        $backendModulesConfiguration = require ExtensionManagementUtility::extPath( // NOSONAR
-            'nr_textdb',
-            'Configuration/Backend/Modules.php',
-        );
-
-        $reflectionClass = new ReflectionClass(TranslationController::class);
-
-        self::assertSame(
-            $backendModulesConfiguration['netresearch_textdb']['controllerActions'][TranslationController::class],
-            $reflectionClass->getConstant('KNOWN_REFERRER_ACTIONS'),
-        );
     }
 
     #[Test]

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -592,8 +592,8 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // whenever the field name matches, even a rejected one. Casting the
         // rejected array to a string to render it crashed the page with
         // "Array to string conversion", live-reproduced against a real
-        // TYPO3 v14.3 backend (sobol typo3-14) before this was changed to a
-        // redirect, which starts a fresh GET with no submitted body left to
+        // TYPO3 v14.3 backend before this was changed to a redirect, which
+        // starts a fresh GET with no submitted body left to
         // repopulate from. A direct translateRecordAction() call cannot
         // reproduce this, it never renders the forward target's view.
         $response = $this->dispatchModuleAction(

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -729,7 +729,10 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // action were ever removed from Configuration/Backend/Modules.php
         // without also being removed here, the allowlist would let it
         // through and uriFor() would fail to resolve it after all.
-        $backendModulesConfiguration = require ExtensionManagementUtility::extPath(
+        // require_once would return true instead of the array here, this
+        // file is already loaded once by TYPO3's own bootstrap by the time
+        // this test runs, and the return value is what this test needs.
+        $backendModulesConfiguration = require ExtensionManagementUtility::extPath( // NOSONAR
             'nr_textdb',
             'Configuration/Backend/Modules.php',
         );

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -33,6 +33,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Crypto\HashAlgo;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -40,12 +42,14 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Core\Bootstrap;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use TYPO3\CMS\Extbase\Security\HashScope;
 
 /**
  * Regression tests for the backend module's save path.
@@ -255,7 +259,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         $extbaseRequestParameters = new ExtbaseRequestParameters(TranslationController::class);
         $extbaseRequestParameters
             ->setControllerExtensionName('NrTextdb')
-            ->setPluginName('Translation')
+            ->setPluginName('netresearch_textdb')
             ->setControllerName('Translation')
             ->setControllerActionName('translateRecord')
             ->setFormat('html');
@@ -569,15 +573,13 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // real Extbase bootstrap rather than called directly, translateRecordAction()
         // still receives update[foo] with the string key intact, proving Extbase's
         // property mapping does not enforce the documented array<int, string> shape.
-        $response = $this->dispatchModuleAction(
-            'translateRecord',
-            [
-                'parent' => '1',
-                'update' => ['foo' => 'x'],
-            ],
-        );
+        $response = $this->dispatchTranslateRecord([
+            'parent' => '1',
+            'update' => ['foo' => 'x'],
+        ]);
 
         self::assertSame(303, $response->getStatusCode());
+        self::assertStringContainsString('Translation/translated', $response->getHeaderLine('Location'));
         self::assertSame('Absenden', $this->fetchValue(5));
     }
 
@@ -596,16 +598,148 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // starts a fresh GET with no submitted body left to
         // repopulate from. A direct translateRecordAction() call cannot
         // reproduce this, it never renders the forward target's view.
-        $response = $this->dispatchModuleAction(
-            'translateRecord',
-            [
-                'parent' => '1',
-                'update' => [1 => ['x']],
-            ],
-        );
+        $response = $this->dispatchTranslateRecord([
+            'parent' => '1',
+            'update' => [1 => ['x']],
+        ]);
 
         self::assertSame(303, $response->getStatusCode());
+        self::assertStringContainsString('Translation/translated', $response->getHeaderLine('Location'));
         self::assertSame('Absenden', $this->fetchValue(5));
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRedirectsInsteadOfForwardingWhenTheParentArgumentFailsToMap(): void
+    {
+        // parent=abc fails Extbase's own int property mapping before
+        // translateRecordAction() ever runs, so this never reaches its
+        // validation at all. The default ActionController::errorAction()
+        // forwards back to the referring "translated" action via a
+        // ForwardResponse, which the Extbase Dispatcher resolves by
+        // re-dispatching within the same request/response, so the browser
+        // never sees it as a real navigation: the address bar and history
+        // entry stay on the failed request (a POST in real module usage,
+        // this dispatch helper always issues a GET, the forward mechanism
+        // is identical either way), and a page refresh would repeat it.
+        // TranslationController overrides errorAction() to redirect there
+        // instead, verified against this exact input: without the
+        // override, this dispatch renders the referring view inline with a
+        // 200 (Failed asserting that 200 is identical to 303); with it,
+        // the browser gets a real 303 to a fresh GET.
+        //
+        // forwardToReferringRequest() only takes that path if a real,
+        // HMAC-signed __referrer is present, exactly what the "translated"
+        // view's own f:form renders into its hidden fields, so this
+        // extracts one from a real render of that view instead of hand-
+        // building an HMAC.
+        $referrer = $this->extractReferrerFields(
+            (string) $this->dispatchModuleAction(
+                'translated',
+                ['uid' => '1'],
+            )->getBody(),
+        );
+
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $referrer,
+        ]);
+
+        self::assertSame(303, $response->getStatusCode());
+        self::assertStringContainsString('Translation/translated', $response->getHeaderLine('Location'));
+        self::assertSame(
+            ['ERROR' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.error.translation.request')]],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteFallsBackToTheDefaultErrorResponseWithoutAReferrer(): void
+    {
+        // Without a __referrer at all (e.g. a direct API call), there is no
+        // '@request' to read, so forwardToReferringRequest() returns null
+        // and errorAction() falls back to the framework's own default
+        // response instead of trying to redirect anywhere. A __referrer
+        // that IS present but fails its HMAC validation is a different
+        // case: that throws, it does not fall back.
+        $response = $this->dispatchTranslateRecord(['parent' => 'abc']);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRejectsAReferrerTargetingAnUnregisteredAction(): void
+    {
+        // The referrer HMAC scope is installation-global, not bound to this
+        // module, so a validly signed __referrer can name any action,
+        // including one that does not exist as a method at all, or this
+        // controller's own non-routed errorAction() itself (which would
+        // forward back into errorAction() again, an infinite loop). The
+        // errorAction() override only forwards to an allowlisted, known-
+        // safe action, so a target outside that list gets a plain error
+        // response instead of ever attempting an internal forward.
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $this->buildSignedReferrer('notARegisteredAction'),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRejectsAReferrerFromAForeignController(): void
+    {
+        // Same installation-global HMAC scope as above, but here the
+        // referrer names a real, routable action, just on a different
+        // controller (as any other Extbase backend module's own form would
+        // sign). Without the controller-name check, this would pass the
+        // action-name allowlist and forward into a controller this module
+        // was never meant to dispatch to.
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $this->buildSignedReferrer('list', 'SomeOtherController'),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRejectsAReferrerFromAForeignExtension(): void
+    {
+        // Same as the foreign-controller case above, but with a matching
+        // controller/action name from a different extension entirely
+        // ('Translation'/'list' happens to also be a plausible controller/
+        // action pair elsewhere), so only the extension-name check catches
+        // it.
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $this->buildSignedReferrer('list', 'Translation', 'SomeOtherExtension'),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function knownReferrerActionsMatchesTheModuleConfig(): void
+    {
+        // errorAction()'s KNOWN_REFERRER_ACTIONS allowlist is what makes
+        // its uriFor() call provably safe (a static, parameter-less backend
+        // route for controller "Translation" plus one of these actions
+        // always resolves), but that safety only holds as long as the list
+        // does not drift ahead of what is actually registered. If an
+        // action were ever removed from Configuration/Backend/Modules.php
+        // without also being removed here, the allowlist would let it
+        // through and uriFor() would fail to resolve it after all.
+        $backendModulesConfiguration = require ExtensionManagementUtility::extPath(
+            'nr_textdb',
+            'Configuration/Backend/Modules.php',
+        );
+
+        $reflectionClass = new ReflectionClass(TranslationController::class);
+
+        self::assertSame(
+            $backendModulesConfiguration['netresearch_textdb']['controllerActions'][TranslationController::class],
+            $reflectionClass->getConstant('KNOWN_REFERRER_ACTIONS'),
+        );
     }
 
     #[Test]
@@ -846,9 +980,11 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
      * read the module and its controller from, and the normalized parameters are
      * what the page renderer of the module template resolves asset paths with.
      *
-     * @param array<string, string|string[]> $queryParams Backend module arguments
-     *                                                    arrive without a plugin
-     *                                                    namespace
+     * @param array<string, string|array<array-key, string|string[]>> $queryParams
+     *                                                                             Backend module
+     *                                                                             arguments arrive
+     *                                                                             without a plugin
+     *                                                                             namespace
      */
     private function dispatchModuleAction(string $action, array $queryParams = []): ResponseInterface
     {
@@ -879,9 +1015,11 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
      * which is the only place that assigns $this->uriBuilder, so the
      * translated-view redirect this action returns dies before it is built
      * (same root cause as dispatchModuleAction()'s own docblock, now hit by
-     * every call since issue #129's fix made the redirect unconditional).
+     * every call since translateRecordAction() started redirecting there
+     * unconditionally, a follow-up hardening found while verifying issue
+     * #129's fix rather than part of #129's original scope).
      *
-     * @param array<string, mixed> $queryParams
+     * @param array<string, string|array<array-key, string|string[]>> $queryParams
      */
     private function dispatchTranslateRecord(array $queryParams): ResponseInterface
     {
@@ -1005,6 +1143,67 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         self::assertIsArray($value, 'Translation record ' . $uid . ' is gone.');
 
         return (string) $value['value'];
+    }
+
+    /**
+     * Builds a validly HMAC-signed __referrer[@request] targeting a chosen
+     * controller/action, the same shape forwardToReferringRequest() expects
+     * (ActionController.php), for exercising referrer targets a real
+     * rendered view never points at, such as an action this module does
+     * not register, or a controller belonging to a different module
+     * entirely (the referrer HMAC scope is installation-global).
+     *
+     * @return array<string, string>
+     */
+    private function buildSignedReferrer(
+        string $action,
+        string $controller = 'Translation',
+        string $extension = 'NrTextdb',
+    ): array {
+        $request = json_encode([
+            '@extension'  => $extension,
+            '@controller' => $controller,
+            '@action'     => $action,
+        ], JSON_THROW_ON_ERROR);
+
+        return [
+            '@request' => $this->get(HashService::class)->appendHmac(
+                $request,
+                HashScope::ReferringRequest->prefix(),
+                HashAlgo::SHA3_256,
+            ),
+        ];
+    }
+
+    /**
+     * Extracts the hidden __referrer[...] fields Fluid's f:form renders into
+     * a real view, so a request can be replayed with a real, HMAC-signed
+     * referrer instead of one built by hand.
+     *
+     * @return array<string, string>
+     */
+    private function extractReferrerFields(string $html): array
+    {
+        preg_match_all(
+            '/name="__referrer\[([^"]+)\]" value="([^"]*)"/',
+            $html,
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        $referrer = [];
+
+        foreach ($matches as $match) {
+            $referrer[$match[1]] = htmlspecialchars_decode($match[2]);
+        }
+
+        self::assertArrayHasKey(
+            '@request',
+            $referrer,
+            'The rendered view must contain a __referrer form to extract fields from.',
+        );
+
+        return $referrer;
     }
 
     /**

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -227,7 +227,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function translateRecordSurfacesAPersistenceFailureAsFlashMessage(): void
     {
-        $persistenceManager = $this->createMock(PersistenceManagerInterface::class);
+        $persistenceManager = self::createStub(PersistenceManagerInterface::class);
         $persistenceManager
             ->method('persistAll')
             ->willThrowException(new RuntimeException('Duplicate entry'));

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -68,7 +68,15 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  * logged "Undefined array key" for placeholder and value, and the "no filter
  * selected" guard of exportAction() compared against null.
  *
+ * The third group covers issue #129: translateRecordAction() trusted the
+ * array keys and values of $new/$update coming straight from the request.
+ * Extbase's property mapping does not enforce the documented element shape at
+ * runtime, so a non-int key, a non-string value, or a language id that is not
+ * configured on any site used to crash the action or silently persist an
+ * unreachable translation.
+ *
  * @see https://github.com/netresearch/t3x-nr-textdb/issues/100
+ * @see https://github.com/netresearch/t3x-nr-textdb/issues/129
  */
 #[CoversClass(TranslationController::class)]
 final class TranslationControllerTest extends AbstractFunctionalTestCase
@@ -94,6 +102,8 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TranslationRepository/Components.csv');
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TranslationRepository/Types.csv');
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TranslationRepository/Translations.csv');
+
+        $this->writeSiteConfiguration();
 
         // Flash messages of the backend module are session bound, so a backend
         // user has to be present for the queue to accept them.
@@ -131,6 +141,11 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
             'Submitting new[0] for an existing default record must not insert a second row.',
         );
         self::assertSame('Send it', $this->fetchValue(1));
+        self::assertSame(
+            ['OK' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')]],
+            $this->flashMessagesGroupedBySeverity(),
+            'A fully valid submission must not also queue the rejected-entries warning.',
+        );
     }
 
     #[Test]
@@ -156,7 +171,11 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
         self::assertSame('Second', $this->fetchValue(1));
-        self::assertSame([], $this->errorFlashMessages(), 'A successful save must not queue an error message.');
+        self::assertSame(
+            ['OK' => array_fill(0, 2, $GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved'))],
+            $this->flashMessagesGroupedBySeverity(),
+            'Two successful saves must not also queue a warning or an error message.',
+        );
     }
 
     #[Test]
@@ -166,6 +185,17 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         $this->controller->translateRecordAction(1, [2 => '   ']);
 
         self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 2));
+        // A blank value is skipped before it reaches saveNewTranslation(), so
+        // it counts as neither accepted nor rejected. The WARNING below comes
+        // not from a rejection but from $nothingWasSaved: something was
+        // submitted and nothing was accepted, so the (misleading, nothing was
+        // saved) success message must not appear either (issue #129 follow-up).
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
     }
 
     #[Test]
@@ -219,6 +249,306 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function translateRecordSkipsAnUpdateValueThatIsNotAString(): void
+    {
+        // Extbase's property mapping does not enforce the array value type
+        // declared in the PHPDoc at runtime. update[5][]=x reaches this method
+        // as ['x'], which used to crash trim() with a TypeError (issue #129,
+        // case 2).
+        $this->controller->translateRecordAction(1, [], [5 => ['x']]);
+
+        self::assertSame('Absenden', $this->fetchValue(5), 'A malformed update value must leave the record untouched.');
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewValueThatIsNotAString(): void
+    {
+        // Same defect on the new[] side: new[0][]=x reaches this method as
+        // [0 => ['x']] and used to crash trim() with a TypeError.
+        $this->controller->translateRecordAction(1, [0 => ['x']]);
+
+        self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
+        self::assertSame('Submit', $this->fetchValue(1), 'A malformed new value must not overwrite the existing record.');
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsAnUpdateKeyThatIsNotAnInteger(): void
+    {
+        // update[foo]=x reaches this method with a string array key, which used
+        // to crash findRawByUid() with a TypeError under strict_types (issue
+        // #129, case 1).
+        $this->controller->translateRecordAction(1, [], ['foo' => 'x']);
+
+        self::assertSame('Absenden', $this->fetchValue(5), 'A malformed update key must leave every record untouched.');
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewKeyThatIsNotAnInteger(): void
+    {
+        // Same defect on the new[] side: a non-numeric array key (e.g. from a
+        // hand-crafted request) reaches this method as a string.
+        $this->controller->translateRecordAction(1, ['foo' => 'x']);
+
+        self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsAnUpdateForANonPositiveUid(): void
+    {
+        // update[0]=x and a negative uid can never address a record, findRawByUid()
+        // would just return null for either, and the not-found case counts as
+        // rejected too (see the else branch in translateRecordAction()). The
+        // early guard here only spares a pointless lookup, it is not what
+        // decides the outcome.
+        $this->controller->translateRecordAction(1, [], [0 => 'x', -3 => 'y']);
+
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsAnUpdateForAUidThatDoesNotExist(): void
+    {
+        // update[999999]=x is well-formed (a positive int key, a string value)
+        // but does not resolve to a record, e.g. deleted between page load and
+        // submit, or a tampered value. Before this fix it was neither accepted
+        // nor rejected, so it was dropped without any signal, same as a
+        // malformed entry used to be before issue #129.
+        $this->controller->translateRecordAction(1, [], [5 => 'Absenden!', 999999 => 'Ghost']);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewEntryWhenTheParentHasNoEnvironmentComponentOrType(): void
+    {
+        // Parent uid 12 carries environment/component/type = 0, the orphaned-row
+        // shape issue #100 already guards against on the update[] side.
+        // saveNewTranslation() returns false for it (createTranslationFromParent()
+        // refuses to build a translation without a real parent relation), and
+        // that must count as rejected too, or a tampered/orphaned parent
+        // silently swallows new[] entries with no signal.
+        $this->controller->translateRecordAction(12, [1 => 'Some text']);
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrtextdb_domain_model_translation');
+
+        self::assertSame(
+            0,
+            (int) $connection->count(
+                'uid',
+                'tx_nrtextdb_domain_model_translation',
+                [
+                    'placeholder'      => 'orphan_test',
+                    'sys_language_uid' => 1,
+                ],
+            ),
+            'A parent without environment/component/type must not produce a new row.',
+        );
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsTheWholeNewPayloadWhenTheParentDoesNotExist(): void
+    {
+        // $parent itself does not resolve to a record (tampered or stale
+        // uid). Every new[] entry is unreachable in that case, and dropping
+        // the whole payload without a signal would defeat the same guarantee
+        // the per-entry checks give: a mixed request with a valid update[]
+        // entry alongside it must still warn about the lost new[] payload,
+        // not just report the unrelated update[] success.
+        $this->controller->translateRecordAction(999999, [0 => 'Some text'], [5 => 'Absenden!']);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordDoesNotWarnWhenTheInvalidParentHasNoNewPayload(): void
+    {
+        // The parent-not-found rejection only applies when new[] actually
+        // carries a payload that becomes unreachable. An update[]-only save
+        // against a stale/tampered parent id must not spuriously warn about a
+        // "lost" new[] submission that was never there.
+        $this->controller->translateRecordAction(999999, [], [5 => 'Absenden!']);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            ['OK' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')]],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordDoesNotWarnWhenTheInvalidParentsNewPayloadIsAllBlank(): void
+    {
+        // A real dialog submit posts one empty new[<language>] textarea per
+        // untranslated language on every save. If the parent happened to be
+        // deleted in the meantime, an editor who only touched the update[]
+        // side must not be told their untouched textareas "could not be
+        // saved", there was nothing there to lose.
+        $this->controller->translateRecordAction(999999, [1 => '   '], [5 => 'Absenden!']);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            ['OK' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')]],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordWarnsWhenTheInvalidParentsNewPayloadIsMalformed(): void
+    {
+        // A malformed (non-string) new[] value is a payload, not a blank, so
+        // it must count towards the "lost payload" warning the same way a
+        // real typed value does, even though the parent doesn't exist either.
+        $this->controller->translateRecordAction(999999, [0 => ['x']], [5 => 'Absenden!']);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordQueuesNoFlashMessageForAnEmptySubmission(): void
+    {
+        // parent alone, without any new[]/update[] payload, is a no-op: not a
+        // rejection (nothing was submitted to reject) and not a save either.
+        $this->controller->translateRecordAction(1);
+
+        self::assertSame([], $this->flashMessagesGroupedBySeverity());
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewEntryForALanguageThatIsNotConfiguredOnTheFirstSite(): void
+    {
+        // new[999]=Text reaches this method with a syntactically valid but
+        // meaningless language id. Before the fix this silently persisted a
+        // translation that could never be reached again through the translation
+        // dialog, since that only lists the site's configured languages (issue
+        // #129, case 3). getAllLanguages() resolves the first configured site
+        // only (see TranslationService::getAllLanguages()), hence "first site"
+        // rather than "any site" in this test's name.
+        $this->controller->translateRecordAction(1, [999 => 'Some text']);
+
+        self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 999));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewEntryForANegativeLanguageId(): void
+    {
+        // The issue notes negative language ids pass through "in the same way"
+        // as out-of-range positive ones. getAllLanguages() never configures a
+        // negative language id, so this is rejected the same way as case 3.
+        $this->controller->translateRecordAction(1, [-5 => 'Some text']);
+
+        self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: -5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSavesAMixOfValidAndRejectedEntries(): void
+    {
+        // The valid entry is saved and reported. The rejected one is not
+        // silently dropped either, a real dialog submission always carries at
+        // least one valid update[] entry (the record itself, echoed back), so
+        // an "only warn when nothing at all was saved" rule would never fire
+        // for a tampered entry submitted alongside a normal save.
+        $this->controller->translateRecordAction(1, [0 => 'Send it', 999 => 'Rejected']);
+
+        self::assertSame('Send it', $this->fetchValue(1));
+        self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 999));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordActionThroughTheModuleRouteAcceptsAMalformedUpdateKeyWithoutCrashing(): void
+    {
+        // Confirms the premise of issue #129 end to end: dispatched through the
+        // real Extbase bootstrap rather than called directly, translateRecordAction()
+        // still receives update[foo] with the string key intact, proving Extbase's
+        // property mapping does not enforce the documented array<int, string> shape.
+        $response = $this->dispatchModuleAction(
+            'translateRecord',
+            [
+                'parent' => '1',
+                'update' => ['foo' => 'x'],
+            ],
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Absenden', $this->fetchValue(5));
+    }
+
+    #[Test]
     public function exportWithoutAStoredFilterIsRefused(): void
     {
         // A backend user that has never opened the module has no stored config.
@@ -236,7 +566,6 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function exportWithAStoredFilterIsCarriedOut(): void
     {
-        $this->writeSiteConfiguration();
         $this->storeFilterConfig(['component' => 1]);
 
         $response = $this->dispatchModuleAction('export');
@@ -256,7 +585,6 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     {
         // The export filters by component and type, and either one on its own is
         // a filter. Only both being unset means "no filter selected".
-        $this->writeSiteConfiguration();
         $this->storeFilterConfig(['type' => 2]);
 
         $response = $this->dispatchModuleAction('export');
@@ -304,7 +632,6 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     {
         // The repository signature is (int, int, ?string, ?string), so an array
         // or an int reaching it would be a TypeError under strict_types.
-        $this->writeSiteConfiguration();
         $this->storeFilterConfig(
             [
                 'component'   => 1,
@@ -486,14 +813,17 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     }
 
     /**
-     * Publishes a site with two languages.
+     * Publishes a site with three languages (English, German, French).
      *
-     * The export iterates the languages of the first site. Without one it
-     * produces no file at all. typo3/testing-framework 9 has no helper for this
-     * any more, and a SiteFinder mock via GeneralUtility::addInstance() does not
-     * work here either, because the controller is built by the container. The
-     * configuration is therefore written to the test instance, where tearDown()
-     * removes it again together with its cache.
+     * Called from setUp() for every test: translateRecordAction() now checks
+     * new[] language ids against the site's configured languages (issue
+     * #129), and the export actions iterate the languages of the first site
+     * and produce no file at all without one. typo3/testing-framework 9 has
+     * no helper for this any more, and a SiteFinder mock via
+     * GeneralUtility::addInstance() does not work here either, because the
+     * controller is built by the container. The configuration is therefore
+     * written to the test instance, where tearDown() removes it again
+     * together with its cache.
      */
     private function writeSiteConfiguration(): void
     {
@@ -517,6 +847,10 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
                     title: German
                     locale: de_DE.UTF-8
                     base: /de/
+                  - languageId: 2
+                    title: French
+                    locale: fr_FR.UTF-8
+                    base: /fr/
                 YAML,
         );
 
@@ -604,18 +938,42 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
      */
     private function errorFlashMessages(): array
     {
+        return $this->flashMessagesOfSeverity(ContextualFeedbackSeverity::ERROR);
+    }
+
+    /**
+     * Returns the texts of all queued flash messages of the given severity.
+     * Flushes the whole queue, so a second call (of this or any of the three
+     * severity-specific helpers above) returns an empty result. Call at most
+     * once per test, use flashMessagesGroupedBySeverity() directly if more
+     * than one severity needs checking.
+     *
+     * @return string[]
+     */
+    private function flashMessagesOfSeverity(ContextualFeedbackSeverity $severity): array
+    {
+        return $this->flashMessagesGroupedBySeverity()[$severity->name] ?? [];
+    }
+
+    /**
+     * Returns the texts of all queued flash messages, grouped by severity
+     * name. Flushes the whole queue, so call this (or one of the
+     * severity-specific helpers above) at most once per test.
+     *
+     * @return array<string, string[]>
+     */
+    private function flashMessagesGroupedBySeverity(): array
+    {
         $messages = $this->get(FlashMessageService::class)
             ->getMessageQueueByIdentifier()
             ->getAllMessagesAndFlush();
 
-        $texts = [];
+        $grouped = [];
 
         foreach ($messages as $message) {
-            if ($message->getSeverity() === ContextualFeedbackSeverity::ERROR) {
-                $texts[] = $message->getMessage();
-            }
+            $grouped[$message->getSeverity()->name][] = $message->getMessage();
         }
 
-        return $texts;
+        return $grouped;
     }
 }

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
+use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Template\Components\ComponentFactory;
@@ -41,6 +42,9 @@ use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Core\Bootstrap;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
 /**
@@ -133,7 +137,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // The dialog renders a new[0] textarea whenever the default-language row
         // is not part of its "translated" list. Before the fix this inserted a
         // second language-0 row for the same placeholder.
-        $this->controller->translateRecordAction(1, [0 => 'Send it']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'Send it']]);
 
         self::assertSame(
             1,
@@ -151,7 +155,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function translateRecordUpdatesAnExistingLocalizedRecordSubmittedAsNew(): void
     {
-        $this->controller->translateRecordAction(1, [1 => 'Abschicken']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [1 => 'Abschicken']]);
 
         self::assertSame(
             1,
@@ -166,8 +170,8 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     {
         // The reported reproducer: the first save silently created a duplicate,
         // the second one aborted with "Duplicate entry … for key 'translation'".
-        $this->controller->translateRecordAction(1, [0 => 'First']);
-        $this->controller->translateRecordAction(1, [0 => 'Second']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'First']]);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'Second']]);
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
         self::assertSame('Second', $this->fetchValue(1));
@@ -182,7 +186,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     public function translateRecordSkipsEmptySubmittedValues(): void
     {
         // Language 2 has no record at all; an untouched textarea must not create one.
-        $this->controller->translateRecordAction(1, [2 => '   ']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [2 => '   ']]);
 
         self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 2));
         // A blank value is skipped before it reaches saveNewTranslation(), so
@@ -201,7 +205,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     #[Test]
     public function translateRecordCreatesRecordForALanguageThatHasNone(): void
     {
-        $this->controller->translateRecordAction(1, [2 => 'Envoyer']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [2 => 'Envoyer']]);
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 2));
     }
@@ -212,7 +216,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // update[<uid>] carries the localized uid. Repository::findByUid() is
         // language aware and returned null for the German row in a backend
         // context, so the edit was silently dropped.
-        $this->controller->translateRecordAction(1, [], [5 => 'Absenden!']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [5 => 'Absenden!']]);
 
         self::assertSame('Absenden!', $this->fetchValue(5));
     }
@@ -240,6 +244,35 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
             $this->get(ComponentFactory::class),
         );
 
+        // translateRecordAction() always redirects now, which needs $request/
+        // $uriBuilder populated by ActionController::processRequest(), and
+        // this manually-constructed instance (needed for the mocked
+        // PersistenceManagerInterface) never goes through it, so both are
+        // built by hand here, minimally, just enough for redirectToUri() not
+        // to crash. Extbase controllers are not shared in the container
+        // (each dispatch gets its own instance), so there is no already-
+        // initialized instance to borrow this state from either.
+        $extbaseRequestParameters = new ExtbaseRequestParameters(TranslationController::class);
+        $extbaseRequestParameters
+            ->setControllerExtensionName('NrTextdb')
+            ->setPluginName('Translation')
+            ->setControllerName('Translation')
+            ->setControllerActionName('translateRecord')
+            ->setFormat('html');
+
+        $extbaseRequest = new ExtbaseRequest(
+            (new ServerRequest('https://example.com/typo3/module/netresearch/textdb', 'POST'))
+                ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+                ->withAttribute('extbase', $extbaseRequestParameters),
+        );
+
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        $uriBuilder->setRequest($extbaseRequest);
+
+        $reflectionClass = new ReflectionClass(TranslationController::class);
+        $reflectionClass->getProperty('request')->setValue($controller, $extbaseRequest);
+        $reflectionClass->getProperty('uriBuilder')->setValue($controller, $uriBuilder);
+
         $controller->translateRecordAction(1, [0 => 'Send it']);
 
         $messages = $this->errorFlashMessages();
@@ -255,7 +288,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // declared in the PHPDoc at runtime. update[5][]=x reaches this method
         // as ['x'], which used to crash trim() with a TypeError (issue #129,
         // case 2).
-        $this->controller->translateRecordAction(1, [], [5 => ['x']]);
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [5 => ['x']]]);
 
         self::assertSame('Absenden', $this->fetchValue(5), 'A malformed update value must leave the record untouched.');
         self::assertSame(
@@ -271,7 +304,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     {
         // Same defect on the new[] side: new[0][]=x reaches this method as
         // [0 => ['x']] and used to crash trim() with a TypeError.
-        $this->controller->translateRecordAction(1, [0 => ['x']]);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => ['x']]]);
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
         self::assertSame('Submit', $this->fetchValue(1), 'A malformed new value must not overwrite the existing record.');
@@ -289,7 +322,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // update[foo]=x reaches this method with a string array key, which used
         // to crash findRawByUid() with a TypeError under strict_types (issue
         // #129, case 1).
-        $this->controller->translateRecordAction(1, [], ['foo' => 'x']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => ['foo' => 'x']]);
 
         self::assertSame('Absenden', $this->fetchValue(5), 'A malformed update key must leave every record untouched.');
         self::assertSame(
@@ -305,7 +338,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     {
         // Same defect on the new[] side: a non-numeric array key (e.g. from a
         // hand-crafted request) reaches this method as a string.
-        $this->controller->translateRecordAction(1, ['foo' => 'x']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => ['foo' => 'x']]);
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
         self::assertSame(
@@ -324,7 +357,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // rejected too (see the else branch in translateRecordAction()). The
         // early guard here only spares a pointless lookup, it is not what
         // decides the outcome.
-        $this->controller->translateRecordAction(1, [], [0 => 'x', -3 => 'y']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [0 => 'x', -3 => 'y']]);
 
         self::assertSame(
             [
@@ -342,7 +375,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // submit, or a tampered value. Before this fix it was neither accepted
         // nor rejected, so it was dropped without any signal, same as a
         // malformed entry used to be before issue #129.
-        $this->controller->translateRecordAction(1, [], [5 => 'Absenden!', 999999 => 'Ghost']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [5 => 'Absenden!', 999999 => 'Ghost']]);
 
         self::assertSame('Absenden!', $this->fetchValue(5));
         self::assertSame(
@@ -363,7 +396,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // refuses to build a translation without a real parent relation), and
         // that must count as rejected too, or a tampered/orphaned parent
         // silently swallows new[] entries with no signal.
-        $this->controller->translateRecordAction(12, [1 => 'Some text']);
+        $this->dispatchTranslateRecord(['parent' => '12', 'new' => [1 => 'Some text']]);
 
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('tx_nrtextdb_domain_model_translation');
@@ -397,7 +430,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // the per-entry checks give: a mixed request with a valid update[]
         // entry alongside it must still warn about the lost new[] payload,
         // not just report the unrelated update[] success.
-        $this->controller->translateRecordAction(999999, [0 => 'Some text'], [5 => 'Absenden!']);
+        $this->dispatchTranslateRecord(['parent' => '999999', 'new' => [0 => 'Some text'], 'update' => [5 => 'Absenden!']]);
 
         self::assertSame('Absenden!', $this->fetchValue(5));
         self::assertSame(
@@ -416,7 +449,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // carries a payload that becomes unreachable. An update[]-only save
         // against a stale/tampered parent id must not spuriously warn about a
         // "lost" new[] submission that was never there.
-        $this->controller->translateRecordAction(999999, [], [5 => 'Absenden!']);
+        $this->dispatchTranslateRecord(['parent' => '999999', 'update' => [5 => 'Absenden!']]);
 
         self::assertSame('Absenden!', $this->fetchValue(5));
         self::assertSame(
@@ -433,7 +466,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // deleted in the meantime, an editor who only touched the update[]
         // side must not be told their untouched textareas "could not be
         // saved", there was nothing there to lose.
-        $this->controller->translateRecordAction(999999, [1 => '   '], [5 => 'Absenden!']);
+        $this->dispatchTranslateRecord(['parent' => '999999', 'new' => [1 => '   '], 'update' => [5 => 'Absenden!']]);
 
         self::assertSame('Absenden!', $this->fetchValue(5));
         self::assertSame(
@@ -448,7 +481,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // A malformed (non-string) new[] value is a payload, not a blank, so
         // it must count towards the "lost payload" warning the same way a
         // real typed value does, even though the parent doesn't exist either.
-        $this->controller->translateRecordAction(999999, [0 => ['x']], [5 => 'Absenden!']);
+        $this->dispatchTranslateRecord(['parent' => '999999', 'new' => [0 => ['x']], 'update' => [5 => 'Absenden!']]);
 
         self::assertSame('Absenden!', $this->fetchValue(5));
         self::assertSame(
@@ -465,7 +498,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     {
         // parent alone, without any new[]/update[] payload, is a no-op: not a
         // rejection (nothing was submitted to reject) and not a save either.
-        $this->controller->translateRecordAction(1);
+        $this->dispatchTranslateRecord(['parent' => '1']);
 
         self::assertSame([], $this->flashMessagesGroupedBySeverity());
     }
@@ -480,7 +513,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // #129, case 3). getAllLanguages() resolves the first configured site
         // only (see TranslationService::getAllLanguages()), hence "first site"
         // rather than "any site" in this test's name.
-        $this->controller->translateRecordAction(1, [999 => 'Some text']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [999 => 'Some text']]);
 
         self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 999));
         self::assertSame(
@@ -497,7 +530,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // The issue notes negative language ids pass through "in the same way"
         // as out-of-range positive ones. getAllLanguages() never configures a
         // negative language id, so this is rejected the same way as case 3.
-        $this->controller->translateRecordAction(1, [-5 => 'Some text']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [-5 => 'Some text']]);
 
         self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: -5));
         self::assertSame(
@@ -516,7 +549,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
         // least one valid update[] entry (the record itself, echoed back), so
         // an "only warn when nothing at all was saved" rule would never fire
         // for a tampered entry submitted alongside a normal save.
-        $this->controller->translateRecordAction(1, [0 => 'Send it', 999 => 'Rejected']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'Send it', 999 => 'Rejected']]);
 
         self::assertSame('Send it', $this->fetchValue(1));
         self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 999));
@@ -530,7 +563,7 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    public function translateRecordActionThroughTheModuleRouteAcceptsAMalformedUpdateKeyWithoutCrashing(): void
+    public function translateRecordThroughTheRouteAcceptsAMalformedUpdateKey(): void
     {
         // Confirms the premise of issue #129 end to end: dispatched through the
         // real Extbase bootstrap rather than called directly, translateRecordAction()
@@ -544,7 +577,34 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
             ],
         );
 
-        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(303, $response->getStatusCode());
+        self::assertSame('Absenden', $this->fetchValue(5));
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteAcceptsAMalformedArrayValue(): void
+    {
+        // The action itself rejects update[1][]=x before touching the record
+        // (see translateRecordSkipsAnUpdateValueThatIsNotAString), but the
+        // forward this action used to return re-rendered the "translated"
+        // view within the SAME request, and Fluid's f:form.textarea
+        // repopulates a field from the request's own submitted value
+        // whenever the field name matches, even a rejected one. Casting the
+        // rejected array to a string to render it crashed the page with
+        // "Array to string conversion", live-reproduced against a real
+        // TYPO3 v14.3 backend (sobol typo3-14) before this was changed to a
+        // redirect, which starts a fresh GET with no submitted body left to
+        // repopulate from. A direct translateRecordAction() call cannot
+        // reproduce this, it never renders the forward target's view.
+        $response = $this->dispatchModuleAction(
+            'translateRecord',
+            [
+                'parent' => '1',
+                'update' => [1 => ['x']],
+            ],
+        );
+
+        self::assertSame(303, $response->getStatusCode());
         self::assertSame('Absenden', $this->fetchValue(5));
     }
 
@@ -810,6 +870,22 @@ final class TranslationControllerTest extends AbstractFunctionalTestCase
 
         return $this->get(Bootstrap::class)
             ->handleBackendRequest($request);
+    }
+
+    /**
+     * Dispatches translateRecordAction() through the real Extbase bootstrap.
+     *
+     * Calling the action directly skips ActionController::processRequest(),
+     * which is the only place that assigns $this->uriBuilder, so the
+     * translated-view redirect this action returns dies before it is built
+     * (same root cause as dispatchModuleAction()'s own docblock, now hit by
+     * every call since issue #129's fix made the redirect unconditional).
+     *
+     * @param array<string, mixed> $queryParams
+     */
+    private function dispatchTranslateRecord(array $queryParams): ResponseInterface
+    {
+        return $this->dispatchModuleAction('translateRecord', $queryParams);
     }
 
     /**

--- a/Tests/Functional/Domain/Repository/TranslationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TranslationRepositoryTest.php
@@ -85,12 +85,12 @@ final class TranslationRepositoryTest extends AbstractFunctionalTestCase
         $result = $this->translationRepository
             ->findAllByComponentTypePlaceholderValueAndLanguage();
 
-        // Fixture contains 11 rows; uid 9 is deleted (still returned because
+        // Fixture contains 12 rows. Uid 9 is deleted (still returned because
         // ignoreEnableFields=true is set inside the method), uid 10 is hidden
         // (same reason). The method does NOT add any where-clause when all
         // parameters keep their defaults, so all non-deleted-via-TCA rows come back.
         // Extbase default query respects the "deleted" flag even with ignoreEnableFields=true
-        // (deleted is a hard exclusion). So uid 9 (deleted=1) is excluded → 10 rows.
+        // (deleted is a hard exclusion). So uid 9 (deleted=1) is excluded → 11 rows.
         self::assertGreaterThanOrEqual(1, $result->count());
     }
 

--- a/Tests/Functional/Fixtures/TranslationRepository/Translations.csv
+++ b/Tests/Functional/Fixtures/TranslationRepository/Translations.csv
@@ -11,3 +11,4 @@
 ,9,1,0,0,0,0,1,0,8,1,1,1,"deleted_entry","Should Not Appear"
 ,10,1,0,0,0,0,0,1,9,1,1,1,"hidden_entry","Hidden Entry"
 ,11,1,0,0,0,0,0,0,10,2,1,1,"submit","Staging Submit"
+,12,1,0,0,0,0,0,0,11,0,0,0,"orphan_test","Orphan"


### PR DESCRIPTION
## Summary

- `translateRecordAction()` trusted the array keys and values of `new[]`/`update[]` straight from the request. Extbase's property mapping does not enforce the documented `array<int, string>` shape at runtime, so a non-int key, a non-string value, or an array value crashed the action with an uncaught `TypeError` under `strict_types`.
- A syntactically valid but unconfigured `sys_language_uid` (e.g. `new[999]=Text`) was silently persisted, permanently occupying a unique-key slot for a translation that could never be reached again through the dialog.
- Both loops now validate key type, value type, and (for `new[]`) that the language is actually configured on the site, before touching a record. A well-formed but non-existent `update[<uid>]`, and a `new[]` entry whose parent is missing its environment/component/type relation, are now counted as rejected too, instead of being dropped with no signal.
- `saveNewTranslation()` now reports back whether it actually wrote a record. The flash message distinguishes a full save from a submission where some or all entries were rejected, instead of unconditionally claiming success even when nothing (or only part of the request) was actually saved.
- `translateRecordAction()` now redirects instead of forwarding to the "translated" view on completion. A forward keeps the failed request's own submitted values alive for Fluid's sticky-value repopulation, which crashed rendering a rejected array value ("Array to string conversion") even though nothing was ever persisted.
- Extbase's own default `errorAction()` independently forwards back to the referring view on any argument-mapping failure (e.g. a non-numeric `parent`), hitting the same class of issue. `TranslationController` now overrides `errorAction()` to redirect there instead, and queues a proper session-backed flash message (the default one is request-transient and would be lost on a redirect). Because the referrer's HMAC signature is installation-global rather than scoped to this extension, the override only forwards to an explicit allowlist of controller, extension and action that mirrors what `Configuration/Backend/Modules.php` registers, closing a path where a validly-signed referrer copied from any other Extbase backend module could otherwise trigger an unhandled exception or an internal forward loop.

## Test plan

- [x] 4 new/updated functional tests reproduce all 3 failure modes from the issue and fail against the pre-fix controller
- [x] Additional tests cover the follow-on gaps found in review: non-existent `update[]` uid, `new[]` against a parent with no environment/component/type, `new[]` against a non-existent parent (with and without a real payload), and a mixed valid+rejected submission
- [x] One test dispatches through the real Extbase bootstrap (`Bootstrap::handleBackendRequest`) rather than calling the controller directly, to prove the request-mapping premise end to end
- [x] Further tests cover the redirect-instead-of-forward fix and the `errorAction()` override, including the referrer-allowlist edge cases (unregistered action, foreign controller, foreign extension) and a drift guard asserting the allowlist matches the registered module config
- [x] `composer ci:test:php:lint` / `:phpstan` / `:rector` / `:cgl` / `:unit` / `:functional` all green
- [x] `composer ci:test:php:fractor` still red, pre-existing and unrelated (tracked in #128, the job is already `skipped` in this repo's CI)
- [x] Live-verified against a real TYPO3 v14.3 backend, both the crashes this PR fixes and the fixed behavior

## Related

Things surfaced during review that are real but out of scope for this fix, filed separately:
- #137 — `TranslationService::getAllLanguages()` resolves the first configured site only, not necessarily the site the module's data belongs to
- #138 — `update[<uid>]` never checks the uid actually belongs to the submitted `parent`'s family
- #142 — the module's own AJAX save flow swallows every flash message, success or error, regardless of this fix
- #143 — a separate, framework-wide crash when `parent` is submitted as an array rather than a scalar

Fixes #129
