### PR TITLE
fix: correct capitalization typo in German translation label

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="tx_nrtextdb_domain_model_translation" approved="yes">
         <source>Translation</source>
-        <target state="final">ÜBersetzung</target>
+        <target state="final">Übersetzung</target>
       </trans-unit>
       <trans-unit id="tx_nrtextdb_domain_model_translation.value" approved="yes">
         <source>Value</source>


### PR DESCRIPTION
`tx_nrtextdb_domain_model_translation`'s German target read "ÜBersetzung" (stray capital B) instead of "Übersetzung". Found incidentally while reviewing #129's German translation additions, unrelated to that fix.