### PR TITLE
chore: fix build artifact leakage and missing plugin trust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ coverage/
 .php-cs-fixer.cache
 .phplint.cache
 
+# On at least one real build environment, `composer install` reproducibly
+# leaves a top-level var/ at the extension root (live-verified 25.08.2026).
+# The triggering composer-time code path has not been identified, ignoring
+# it defensively until isolated.
+/var/
+
 # DDEV
 .ddev/.homeadditions
 .ddev/.ddev-docker-compose-full.yaml

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
             "a9f/fractor-extension-installer": true,
             "captainhook/hook-installer": true,
             "dg/bypass-finals": true,
+            "ergebnis/composer-normalize": true,
             "infection/extension-installer": true,
             "phpstan/extension-installer": true,
             "typo3/class-alias-loader": true,


### PR DESCRIPTION
## Summary

Two small, unrelated build/tooling papercuts found while running `composer install`/`composer ci:test` for a different branch.

- `composer install` prompted interactively to trust `ergebnis/composer-normalize`, a real transitive dependency (via `netresearch/typo3-ci-workflows`) that was missing from `config.allow-plugins`. Confirmed the plugin only registers a `composer normalize` command and runs no code automatically during install/update.
- On at least one real build environment, `composer install` reproducibly leaves a top-level `var/` directory at the extension root instead of under `.Build/`. The triggering composer-time code path was not identified (TYPO3's own asset-publishing installer writes its cache to `<vendor-dir>/typo3`, not here, so that specific step is ruled out), ignored defensively via `.gitignore` until isolated.

## Test plan

- [x] Live-verified in the real project buildbox: `composer install` no longer prompts for `ergebnis/composer-normalize` trust, and `composer.json` is no longer modified as a side effect
- [x] `composer.json` validated as well-formed JSON
- [x] `composer ci:test:php:cgl` green
- [x] No functional/unit test applies, this is build-tooling-only, no application code touched