### PR TITLE
Backport of #139 to TYPO3_13: reject malformed and unconfigured translateRecordAction() input

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1,19 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			# False positive: saschaegerer/phpstan-typo3 3.0.0 registers
-			# forwardToReferringRequest() as an early-terminating call, so
-			# PHPStan treats the code after it as dead. TYPO3 v13.4's actual
-			# implementation does follow this normal ?ResponseInterface
-			# return path (verified against the installed vendor source), it
-			# only throws on a malformed/tampered __referrer, a separate,
-			# pre-existing case this override does not add handling for.
-			message: '#^Unreachable statement - code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: ../Classes/Controller/TranslationController.php
-
-		-
 			message: '#^Instanceof between Netresearch\\NrTextdb\\Domain\\Model\\Translation and Netresearch\\NrTextdb\\Domain\\Model\\Translation will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -2,9 +2,12 @@ parameters:
 	ignoreErrors:
 		-
 			# False positive: saschaegerer/phpstan-typo3 3.0.0 registers
-			# forwardToReferringRequest() as an early-terminating call. TYPO3
-			# v13.4's actual implementation returns ?ResponseInterface and
-			# never throws, verified against the installed vendor source.
+			# forwardToReferringRequest() as an early-terminating call, so
+			# PHPStan treats the code after it as dead. TYPO3 v13.4's actual
+			# implementation does follow this normal ?ResponseInterface
+			# return path (verified against the installed vendor source), it
+			# only throws on a malformed/tampered __referrer, a separate,
+			# pre-existing case this override does not add handling for.
 			message: '#^Unreachable statement - code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 1

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			# False positive: saschaegerer/phpstan-typo3 3.0.0 registers
+			# forwardToReferringRequest() as an early-terminating call. TYPO3
+			# v13.4's actual implementation returns ?ResponseInterface and
+			# never throws, verified against the installed vendor source.
+			message: '#^Unreachable statement - code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: ../Classes/Controller/TranslationController.php
+
+		-
 			message: '#^Instanceof between Netresearch\\NrTextdb\\Domain\\Model\\Translation and Netresearch\\NrTextdb\\Domain\\Model\\Translation will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -18,6 +18,29 @@ parameters:
         - %currentWorkingDirectory%/Configuration/Backend/Modules.php
         - %currentWorkingDirectory%/Tests/Functional/*
 
+    # This entry lives here, hand-maintained, rather than in the auto-generated
+    # Build/phpstan-baseline.neon: `composer ci:test:php:phpstan:baseline`
+    # regenerates that file from a real run's findings and would silently
+    # discard this comment (and the entry itself, once the underlying
+    # forwardToReferringRequest() call it targets stops producing a real
+    # finding for some unrelated reason, at which point this becomes dead
+    # config to remove instead of a stale-but-still-firing baseline line).
+    #
+    # False positive: saschaegerer/phpstan-typo3 3.0.0 registers
+    # forwardToReferringRequest() as an early-terminating call, so PHPStan
+    # treats the code after it as dead. TYPO3 v13.4's actual implementation
+    # does follow this normal ?ResponseInterface return path (verified
+    # against the installed vendor source), it only throws on a
+    # malformed/tampered __referrer, a separate, pre-existing case
+    # Classes/Controller/TranslationController.php's errorAction() override
+    # does not add handling for.
+    ignoreErrors:
+        -
+            message: '#^Unreachable statement - code above always terminates\.$#'
+            identifier: deadCode.unreachable
+            count: 1
+            path: %currentWorkingDirectory%/Classes/Controller/TranslationController.php
+
     # ergebnis/phpstan-rules is auto-registered by phpstan/extension-installer
     # (transitively required via netresearch/typo3-ci-workflows). Its default
     # ruleset (allRules: true) forbids extending TYPO3/Symfony/PHPUnit framework

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -41,6 +41,21 @@ parameters:
             count: 1
             path: %currentWorkingDirectory%/Classes/Controller/TranslationController.php
 
+        # False positive: $language in this loop is a key of
+        # TranslationService::getAllLanguages()'s return value, checked with
+        # array_key_exists() right above the loop, so it can only ever be one
+        # of that array's real keys (a configured, non-negative language id).
+        # With the phpstan/phpstan 2.2.9 + saschaegerer/phpstan-typo3 3.0.0
+        # combination this branch's composer.json currently resolves,
+        # PHPStan does not narrow $language's type from that
+        # array_key_exists() check, and only sees its declared int type
+        # widened back out to a plain int by the foreach.
+        -
+            message: '#^Parameter \#2 \$language of method Netresearch\\NrTextdb\\Controller\\TranslationController\:\:saveNewTranslation\(\) expects int\<\-1, max\>, int given\.$#'
+            identifier: argument.type
+            count: 1
+            path: %currentWorkingDirectory%/Classes/Controller/TranslationController.php
+
     # ergebnis/phpstan-rules is auto-registered by phpstan/extension-installer
     # (transitively required via netresearch/typo3-ci-workflows). Its default
     # ruleset (allRules: true) forbids extending TYPO3/Symfony/PHPUnit framework

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -41,21 +41,6 @@ parameters:
             count: 1
             path: %currentWorkingDirectory%/Classes/Controller/TranslationController.php
 
-        # False positive: $language in this loop is a key of
-        # TranslationService::getAllLanguages()'s return value, checked with
-        # array_key_exists() right above the loop, so it can only ever be one
-        # of that array's real keys (a configured, non-negative language id).
-        # With the phpstan/phpstan 2.2.9 + saschaegerer/phpstan-typo3 3.0.0
-        # combination this branch's composer.json currently resolves,
-        # PHPStan does not narrow $language's type from that
-        # array_key_exists() check, and only sees its declared int type
-        # widened back out to a plain int by the foreach.
-        -
-            message: '#^Parameter \#2 \$language of method Netresearch\\NrTextdb\\Controller\\TranslationController\:\:saveNewTranslation\(\) expects int\<\-1, max\>, int given\.$#'
-            identifier: argument.type
-            count: 1
-            path: %currentWorkingDirectory%/Classes/Controller/TranslationController.php
-
     # ergebnis/phpstan-rules is auto-registered by phpstan/extension-installer
     # (transitively required via netresearch/typo3-ci-workflows). Its default
     # ruleset (allRules: true) forbids extending TYPO3/Symfony/PHPUnit framework

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -285,6 +285,14 @@ final class TranslationController extends ActionController
      */
     protected function errorAction(): ResponseInterface
     {
+        // saschaegerer/phpstan-typo3 3.0.0 (the version this TYPO3 13 line's
+        // composer.json resolves) registers forwardToReferringRequest() as an
+        // early-terminating call, so PHPStan infers everything below as dead
+        // code. TYPO3 v13.4's actual implementation
+        // (typo3/cms-extbase Classes/Mvc/Controller/ActionController.php)
+        // returns ?ResponseInterface and never throws, verified against the
+        // installed vendor source. The resulting false positive is baselined
+        // in Build/phpstan-baseline.neon.
         $forwardResponse = $this->forwardToReferringRequest();
 
         if (!$forwardResponse instanceof ForwardResponse) {

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -296,7 +296,7 @@ final class TranslationController extends ActionController
         // InvalidArgumentNameException or InvalidHashStringException, same
         // as on TYPO3 v14, and this override does not add handling for that
         // pre-existing case. The resulting dead-code false positive on the
-        // return path is baselined in Build/phpstan-baseline.neon.
+        // return path is ignored in Build/phpstan.neon.
         $forwardResponse = $this->forwardToReferringRequest();
 
         if (!$forwardResponse instanceof ForwardResponse) {
@@ -368,7 +368,6 @@ final class TranslationController extends ActionController
             foreach ($new as $language => $value) {
                 if (
                     !is_int($language)
-                    || ($language < -1)
                     || !is_string($value)
                     || !array_key_exists($language, $allowedLanguages)
                 ) {

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -366,8 +366,17 @@ final class TranslationController extends ActionController
             $allowedLanguages = $this->translationService->getAllLanguages();
 
             foreach ($new as $language => $value) {
+                // The array_key_exists() check below already rejects any
+                // $language that TYPO3\CMS\Core\Site\Entity\Site::
+                // getAllLanguages() didn't configure, this explicit
+                // "$language < -1" is redundant at runtime. It narrows
+                // $language to int<-1, max> for PHPStan, which
+                // saveNewTranslation() below declares as its parameter type
+                // and which PHPStan does not otherwise infer from
+                // array_key_exists() against a site's language array.
                 if (
                     !is_int($language)
+                    || ($language < -1)
                     || !is_string($value)
                     || !array_key_exists($language, $allowedLanguages)
                 ) {

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -290,9 +290,13 @@ final class TranslationController extends ActionController
         // early-terminating call, so PHPStan infers everything below as dead
         // code. TYPO3 v13.4's actual implementation
         // (typo3/cms-extbase Classes/Mvc/Controller/ActionController.php)
-        // returns ?ResponseInterface and never throws, verified against the
-        // installed vendor source. The resulting false positive is baselined
-        // in Build/phpstan-baseline.neon.
+        // follows this normal ?ResponseInterface return path whenever the
+        // request carries no __referrer, or a validly HMAC-signed one; a
+        // malformed or tampered __referrer instead throws
+        // InvalidArgumentNameException or InvalidHashStringException, same
+        // as on TYPO3 v14, and this override does not add handling for that
+        // pre-existing case. The resulting dead-code false positive on the
+        // return path is baselined in Build/phpstan-baseline.neon.
         $forwardResponse = $this->forwardToReferringRequest();
 
         if (!$forwardResponse instanceof ForwardResponse) {

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -285,18 +285,9 @@ final class TranslationController extends ActionController
      */
     protected function errorAction(): ResponseInterface
     {
-        // saschaegerer/phpstan-typo3 3.0.0 (the version this TYPO3 13 line's
-        // composer.json resolves) registers forwardToReferringRequest() as an
-        // early-terminating call, so PHPStan infers everything below as dead
-        // code. TYPO3 v13.4's actual implementation
-        // (typo3/cms-extbase Classes/Mvc/Controller/ActionController.php)
-        // follows this normal ?ResponseInterface return path whenever the
-        // request carries no __referrer, or a validly HMAC-signed one; a
-        // malformed or tampered __referrer instead throws
-        // InvalidArgumentNameException or InvalidHashStringException, same
-        // as on TYPO3 v14, and this override does not add handling for that
-        // pre-existing case. The resulting dead-code false positive on the
-        // return path is ignored in Build/phpstan.neon.
+        // False positive from a saschaegerer/phpstan-typo3 3.0.0 quirk; see
+        // the ignoreErrors entry in Build/phpstan.neon for the full
+        // explanation.
         $forwardResponse = $this->forwardToReferringRequest();
 
         if (!$forwardResponse instanceof ForwardResponse) {

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrTextdb\Controller;
 
+use function array_key_exists;
+use function is_int;
 use function is_numeric;
 use function is_string;
 use function max;
@@ -276,8 +278,62 @@ final class TranslationController extends ActionController
     }
 
     /**
-     * @param array<int<-1, max>, string> $new
-     * @param array<int, string>          $update
+     * Extbase's default errorAction() forwards back to the referring action
+     * within the same request/response, so the browser never sees a real
+     * navigation and a refresh would repeat the failed request. This
+     * redirects there instead.
+     */
+    protected function errorAction(): ResponseInterface
+    {
+        $forwardResponse = $this->forwardToReferringRequest();
+
+        if (!$forwardResponse instanceof ForwardResponse) {
+            return parent::errorAction();
+        }
+
+        // The referrer's HMAC scope is installation-global, not bound to
+        // this extension, but uriFor() builds the route from this
+        // request's own module identifier, so a foreign controller/action
+        // can never resolve outside this module's five routes (empty $uri
+        // below). extensionName is the one value backend routing ignores,
+        // so it needs this explicit check.
+        if ($forwardResponse->getExtensionName() !== 'NrTextdb') {
+            return $this->htmlResponse($this->getFlattenedValidationErrorMessage())
+                ->withStatus(400);
+        }
+
+        $uri = $this->uriBuilder->reset()->uriFor(
+            $forwardResponse->getActionName(),
+            $forwardResponse->getArguments() ?? [],
+            $forwardResponse->getControllerName(),
+            $forwardResponse->getExtensionName(),
+        );
+
+        if ($uri === '') {
+            return $this->htmlResponse($this->getFlattenedValidationErrorMessage())
+                ->withStatus(400);
+        }
+
+        // addErrorFlashMessage() enqueues into a request-transient queue
+        // that only a same-request forward render would ever flush, a
+        // redirect ends the request without rendering it, so the message
+        // would be lost. addFlashMessageToQueue() persists it to the
+        // session-stored queue the module's chrome actually reads.
+        $this->addFlashMessageToQueue(
+            $this->translate('message.translation.save.title') ?? 'TextDb',
+            $this->translate('message.error.translation.request') ?? 'The submitted request could not be processed.',
+        );
+
+        return $this->redirectToUri($uri);
+    }
+
+    /**
+     * $new and $update come straight from the request. Extbase's property
+     * mapping does not enforce the documented element shape at runtime, so
+     * both loops below validate keys and values before touching a record.
+     *
+     * @param array<array-key, string|array<array-key, string>> $new    Expected shape: array<int<-1, max>, string>
+     * @param array<array-key, string|array<array-key, string>> $update Expected shape: array<int, string>
      *
      * @throws IllegalObjectTypeException
      * @throws UnknownObjectException
@@ -285,31 +341,122 @@ final class TranslationController extends ActionController
     public function translateRecordAction(int $parent, array $new = [], array $update = []): ResponseInterface
     {
         $parentTranslation = $this->translationRepository->findRawByUid($parent);
+        $acceptedCount     = 0;
+        $rejectedCount     = 0;
 
         if ($parentTranslation instanceof Translation) {
+            // getAllLanguages() resolves the first configured site only (see
+            // TranslationService::getAllLanguages()), matching the languages
+            // translatedAction() renders as selectable. A language id that is
+            // only configured on another site in a multi-site installation is
+            // rejected here as well, same as it would be unreachable through
+            // the module's own "untranslated" list.
+            $allowedLanguages = $this->translationService->getAllLanguages();
+
             foreach ($new as $language => $value) {
-                $this->saveNewTranslation($parentTranslation, $language, trim($value));
+                if (
+                    !is_int($language)
+                    || ($language < -1)
+                    || !is_string($value)
+                    || !array_key_exists($language, $allowedLanguages)
+                ) {
+                    ++$rejectedCount;
+
+                    continue;
+                }
+
+                $trimmedValue = trim($value);
+
+                if ($trimmedValue === '') {
+                    // An untouched textarea: not a rejection and not a saved
+                    // entry either, it updates neither counter. If it is the
+                    // only thing submitted, $nothingWasSaved still applies
+                    // below.
+                    continue;
+                }
+
+                if ($this->saveNewTranslation($parentTranslation, $language, $trimmedValue)) {
+                    ++$acceptedCount;
+                } else {
+                    ++$rejectedCount;
+                }
+            }
+        } else {
+            // A well-formed, blank entry is the only shape the parent-exists
+            // branch above does not count as a rejection either (it is
+            // silently skipped). Everything else, including a malformed
+            // value, counts as payload here too.
+            $newHasPayload = array_filter(
+                $new,
+                static fn (string|array $value): bool => !is_string($value) || (trim($value) !== ''),
+            ) !== [];
+
+            if ($newHasPayload) {
+                // $parent does not resolve to a record (tampered or stale
+                // value), so a submitted new[] payload is unreachable. Count
+                // it once instead of dropping it without any signal, the
+                // individual entries were never validated far enough to
+                // count them apart.
+                ++$rejectedCount;
             }
         }
 
         foreach ($update as $translationUid => $value) {
+            if (
+                !is_int($translationUid)
+                // A non-positive uid can never match a record. Rejecting it
+                // here avoids a pointless lookup.
+                || ($translationUid <= 0)
+                || !is_string($value)
+            ) {
+                ++$rejectedCount;
+
+                continue;
+            }
+
             $translation = $this->translationRepository->findRawByUid($translationUid);
 
             if ($translation instanceof Translation) {
                 $translation->setValue(trim($value));
 
                 $this->translationRepository->update($translation);
+                ++$acceptedCount;
+            } else {
+                // A well-formed but non-existent uid (deleted between page
+                // load and submit, or a tampered value) must count as
+                // rejected too, or it is dropped without any signal.
+                ++$rejectedCount;
             }
         }
+
+        // A real dialog submission always carries at least one valid update[]
+        // entry (the record itself, echoed back), so a plain "was anything
+        // rejected" flag would rarely fire from the UI and a tampered/invalid
+        // entry submitted alongside a normal save would be dropped silently.
+        // The two conditions below are independent and both flash messages
+        // can appear together, so a partially rejected submission is never
+        // reported as an unqualified success.
+        $nothingWasSaved   = (($new !== []) || ($update !== [])) && ($acceptedCount === 0);
+        $somethingRejected = $rejectedCount > 0;
 
         try {
             $this->persistenceManager->persistAll();
 
-            $this->addFlashMessageToQueue(
-                $this->translate('message.translation.save.title') ?? 'TextDb',
-                $this->translate('message.translation.saved') ?? 'The translation was saved.',
-                ContextualFeedbackSeverity::OK,
-            );
+            if ($nothingWasSaved || $somethingRejected) {
+                $this->addFlashMessageToQueue(
+                    $this->translate('message.translation.save.title') ?? 'TextDb',
+                    $this->translate('message.translation.rejected') ?? 'One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.',
+                    ContextualFeedbackSeverity::WARNING,
+                );
+            }
+
+            if ($acceptedCount > 0) {
+                $this->addFlashMessageToQueue(
+                    $this->translate('message.translation.save.title') ?? 'TextDb',
+                    $this->translate('message.translation.saved') ?? 'The translation was saved.',
+                    ContextualFeedbackSeverity::OK,
+                );
+            }
         } catch (Throwable $throwable) {
             // Without this guard a persistence error (historically a collision
             // with the unique key on the translation table) escaped the module
@@ -326,12 +473,16 @@ final class TranslationController extends ActionController
             );
         }
 
-        return (new ForwardResponse('translated'))
-            ->withControllerName('Translation')
-            ->withExtensionName('NrTextdb')
-            ->withArguments([
-                'uid' => $parent,
-            ]);
+        // A redirect (not a forward) so the browser issues a fresh GET for the
+        // "translated" view. A forward keeps this same POST request active,
+        // and Fluid's form ViewHelpers repopulate a field from the request's
+        // own submitted value whenever the field name matches, even a
+        // rejected one, casting a rejected array value to a string to render
+        // it crashes the page with "Array to string conversion" although
+        // nothing was persisted.
+        return $this->redirectToUri(
+            $this->uriBuilder->reset()->uriFor('translated', ['uid' => $parent]),
+        );
     }
 
     /**
@@ -345,20 +496,23 @@ final class TranslationController extends ActionController
      * misses rows that do exist. Blindly adding a record for each entry
      * therefore produced empty rows and, on the second save, a collision with
      * the unique key (sys_language_uid, pid, environment, component, type,
-     * placeholder, deleted). Skipping empties and updating an existing record
-     * makes that collision impossible by construction. See issue #100.
+     * placeholder, deleted). Updating an existing record instead of adding a
+     * new one makes that collision impossible by construction. See issue
+     * #100. The caller is expected to have already skipped blank values, an
+     * untouched textarea is not a rejection and must not reach this method.
      *
-     * @param int<-1, max> $language
+     * @param int<-1, max>     $language
+     * @param non-empty-string $value
+     *
+     * @return bool TRUE if a record was added or updated, FALSE if the parent
+     *              translation was missing its environment/component/type
+     *              and nothing could be saved
      *
      * @throws IllegalObjectTypeException
      * @throws UnknownObjectException
      */
-    private function saveNewTranslation(Translation $parentTranslation, int $language, string $value): void
+    private function saveNewTranslation(Translation $parentTranslation, int $language, string $value): bool
     {
-        if ($value === '') {
-            return;
-        }
-
         $environment = $parentTranslation->getEnvironment();
         $component   = $parentTranslation->getComponent();
         $type        = $parentTranslation->getType();
@@ -378,7 +532,7 @@ final class TranslationController extends ActionController
 
             $this->translationRepository->update($existingTranslation);
 
-            return;
+            return true;
         }
 
         $translation = $this->translationService
@@ -390,7 +544,11 @@ final class TranslationController extends ActionController
 
         if ($translation instanceof Translation) {
             $this->translationRepository->add($translation);
+
+            return true;
         }
+
+        return false;
     }
 
     /**

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -175,9 +175,21 @@
         <source>Missing value in key: %s</source>
         <target state="final">Fehlender Wert in Schlüssel: %s</target>
       </trans-unit>
+      <trans-unit id="message.translation.saved">
+        <source>The translation was saved.</source>
+        <target state="final">Die Übersetzung wurde gespeichert.</target>
+      </trans-unit>
       <trans-unit id="message.translation.rejected">
         <source>One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.</source>
         <target state="final">Eine oder mehrere der übermittelten Übersetzungen konnten nicht gespeichert werden. Der Datensatz, die Zielsprache oder der übermittelte Wert war ungültig.</target>
+      </trans-unit>
+      <trans-unit id="message.translation.save.title" translate="no">
+        <source>TextDb</source>
+        <target state="needs-translation">TextDb</target>
+      </trans-unit>
+      <trans-unit id="message.error.translation.save">
+        <source>The translation could not be saved: %s</source>
+        <target state="needs-translation">The translation could not be saved: %s</target>
       </trans-unit>
       <trans-unit id="message.error.translation.request">
         <source>The submitted request could not be processed.</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -175,6 +175,14 @@
         <source>Missing value in key: %s</source>
         <target state="final">Fehlender Wert in Schlüssel: %s</target>
       </trans-unit>
+      <trans-unit id="message.translation.rejected">
+        <source>One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.</source>
+        <target state="final">Eine oder mehrere der übermittelten Übersetzungen konnten nicht gespeichert werden. Der Datensatz, die Zielsprache oder der übermittelte Wert war ungültig.</target>
+      </trans-unit>
+      <trans-unit id="message.error.translation.request">
+        <source>The submitted request could not be processed.</source>
+        <target state="final">Die übermittelte Anfrage konnte nicht verarbeitet werden.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -136,11 +136,17 @@
             <trans-unit id="message.translation.saved">
                 <source>The translation was saved.</source>
             </trans-unit>
+            <trans-unit id="message.translation.rejected">
+                <source>One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.</source>
+            </trans-unit>
             <trans-unit id="message.translation.save.title" translate="no">
                 <source>TextDb</source>
             </trans-unit>
             <trans-unit id="message.error.translation.save">
                 <source>The translation could not be saved: %s</source>
+            </trans-unit>
+            <trans-unit id="message.error.translation.request">
+                <source>The submitted request could not be processed.</source>
             </trans-unit>
         </body>
     </file>

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -807,9 +807,6 @@ final class TranslationControllerTest extends FunctionalTestCase
         self::assertSame([], $this->errorFlashMessages());
     }
 
-    /**
-     * @param string $storedConfig Raw payload, as it sits in be_users.uc
-     */
     #[Test]
     public function listingTheModuleTruncatesAFractionalStoredFilter(): void
     {
@@ -827,6 +824,9 @@ final class TranslationControllerTest extends FunctionalTestCase
         );
     }
 
+    /**
+     * @param string $storedConfig Raw payload, as it sits in be_users.uc
+     */
     #[Test]
     #[DataProvider('unusableStoredFilterProvider')]
     public function exportWithAnUnusableStoredFilterIsRefused(string $storedConfig): void

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
+use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
@@ -30,6 +31,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Crypto\HashAlgo;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -39,7 +42,11 @@ use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Core\Bootstrap;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use TYPO3\CMS\Extbase\Security\HashScope;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -68,13 +75,23 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  *   uid 5  language 1  l10n_parent 1                          "submit"    = "Absenden"
  *   uid 8  pid 2       same placeholder on another page, must stay untouched
  *   uid 11 environment 2 same placeholder in another environment, likewise
+ *   uid 12 environment/component/type = 0, an orphaned parent for issue #129's
+ *          "parent has no relation" case
  *
  * The second group of tests covers the module's filter config. A backend user
  * without a stored config used to receive an empty array. listAction() then
  * logged "Undefined array key" for placeholder and value, and the "no filter
  * selected" guard of exportAction() compared against null.
  *
+ * The third group covers issue #129: translateRecordAction() trusted the
+ * array keys and values of $new/$update coming straight from the request.
+ * Extbase's property mapping does not enforce the documented element shape at
+ * runtime, so a non-int key, a non-string value, or a language id that is not
+ * configured on any site used to crash the action or silently persist an
+ * unreachable translation.
+ *
  * @see https://github.com/netresearch/t3x-nr-textdb/issues/100
+ * @see https://github.com/netresearch/t3x-nr-textdb/issues/129
  */
 #[CoversClass(TranslationController::class)]
 final class TranslationControllerTest extends FunctionalTestCase
@@ -128,6 +145,8 @@ final class TranslationControllerTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TranslationRepository/Types.csv');
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/TranslationRepository/Translations.csv');
 
+        $this->writeSiteConfiguration();
+
         // Flash messages of the backend module are session bound, so a backend
         // user has to be present for the queue to accept them.
         $this->setUpBackendUser(1);
@@ -156,7 +175,7 @@ final class TranslationControllerTest extends FunctionalTestCase
         // The dialog renders a new[0] textarea whenever the default-language row
         // is not part of its "translated" list. Before the fix this inserted a
         // second language-0 row for the same placeholder.
-        $this->controller->translateRecordAction(1, [0 => 'Send it']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'Send it']]);
 
         self::assertSame(
             1,
@@ -164,12 +183,17 @@ final class TranslationControllerTest extends FunctionalTestCase
             'Submitting new[0] for an existing default record must not insert a second row.',
         );
         self::assertSame('Send it', $this->fetchValue(1));
+        self::assertSame(
+            ['OK' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')]],
+            $this->flashMessagesGroupedBySeverity(),
+            'A fully valid submission must not also queue the rejected-entries warning.',
+        );
     }
 
     #[Test]
     public function translateRecordUpdatesAnExistingLocalizedRecordSubmittedAsNew(): void
     {
-        $this->controller->translateRecordAction(1, [1 => 'Abschicken']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [1 => 'Abschicken']]);
 
         self::assertSame(
             1,
@@ -184,27 +208,42 @@ final class TranslationControllerTest extends FunctionalTestCase
     {
         // The reported reproducer: the first save silently created a duplicate,
         // the second one aborted with "Duplicate entry … for key 'translation'".
-        $this->controller->translateRecordAction(1, [0 => 'First']);
-        $this->controller->translateRecordAction(1, [0 => 'Second']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'First']]);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'Second']]);
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
         self::assertSame('Second', $this->fetchValue(1));
-        self::assertSame([], $this->errorFlashMessages(), 'A successful save must not queue an error message.');
+        self::assertSame(
+            ['OK' => array_fill(0, 2, $GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved'))],
+            $this->flashMessagesGroupedBySeverity(),
+            'Two successful saves must not also queue a warning or an error message.',
+        );
     }
 
     #[Test]
     public function translateRecordSkipsEmptySubmittedValues(): void
     {
         // Language 2 has no record at all; an untouched textarea must not create one.
-        $this->controller->translateRecordAction(1, [2 => '   ']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [2 => '   ']]);
 
         self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 2));
+        // A blank value is skipped before it reaches saveNewTranslation(), so
+        // it counts as neither accepted nor rejected. The WARNING below comes
+        // not from a rejection but from $nothingWasSaved: something was
+        // submitted and nothing was accepted, so the (misleading, nothing was
+        // saved) success message must not appear either (issue #129 follow-up).
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
     }
 
     #[Test]
     public function translateRecordCreatesRecordForALanguageThatHasNone(): void
     {
-        $this->controller->translateRecordAction(1, [2 => 'Envoyer']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [2 => 'Envoyer']]);
 
         self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 2));
     }
@@ -215,7 +254,7 @@ final class TranslationControllerTest extends FunctionalTestCase
         // update[<uid>] carries the localized uid. Repository::findByUid() is
         // language aware and returned null for the German row in a backend
         // context, so the edit was silently dropped.
-        $this->controller->translateRecordAction(1, [], [5 => 'Absenden!']);
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [5 => 'Absenden!']]);
 
         self::assertSame('Absenden!', $this->fetchValue(5));
     }
@@ -242,12 +281,486 @@ final class TranslationControllerTest extends FunctionalTestCase
             $this->get(FlashMessageService::class),
         );
 
+        // translateRecordAction() always redirects now, which needs $request/
+        // $uriBuilder populated by ActionController::processRequest(), and
+        // this manually-constructed instance (needed for the mocked
+        // PersistenceManagerInterface) never goes through it, so both are
+        // built by hand here, minimally, just enough for redirectToUri() not
+        // to crash. Extbase controllers are not shared in the container
+        // (each dispatch gets its own instance), so there is no already-
+        // initialized instance to borrow this state from either.
+        $extbaseRequestParameters = new ExtbaseRequestParameters(TranslationController::class);
+        $extbaseRequestParameters
+            ->setControllerExtensionName('NrTextdb')
+            ->setPluginName('netresearch_textdb')
+            ->setControllerName('Translation')
+            ->setControllerActionName('translateRecord')
+            ->setFormat('html');
+
+        $extbaseRequest = new ExtbaseRequest(
+            (new ServerRequest('https://example.com/typo3/module/netresearch/textdb', 'POST'))
+                ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+                ->withAttribute('extbase', $extbaseRequestParameters),
+        );
+
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        $uriBuilder->setRequest($extbaseRequest);
+
+        $reflectionClass = new ReflectionClass(TranslationController::class);
+        $reflectionClass->getProperty('request')->setValue($controller, $extbaseRequest);
+        $reflectionClass->getProperty('uriBuilder')->setValue($controller, $uriBuilder);
+
         $controller->translateRecordAction(1, [0 => 'Send it']);
 
         $messages = $this->errorFlashMessages();
 
         self::assertCount(1, $messages);
         self::assertStringContainsString('Duplicate entry', $messages[0]);
+    }
+
+    #[Test]
+    public function translateRecordSkipsAnUpdateValueThatIsNotAString(): void
+    {
+        // Extbase's property mapping does not enforce the array value type
+        // declared in the PHPDoc at runtime. update[5][]=x reaches this method
+        // as ['x'], which used to crash trim() with a TypeError (issue #129,
+        // case 2).
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [5 => ['x']]]);
+
+        self::assertSame('Absenden', $this->fetchValue(5), 'A malformed update value must leave the record untouched.');
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewValueThatIsNotAString(): void
+    {
+        // Same defect on the new[] side: new[0][]=x reaches this method as
+        // [0 => ['x']] and used to crash trim() with a TypeError.
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => ['x']]]);
+
+        self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
+        self::assertSame('Submit', $this->fetchValue(1), 'A malformed new value must not overwrite the existing record.');
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsAnUpdateKeyThatIsNotAnInteger(): void
+    {
+        // update[foo]=x reaches this method with a string array key, which used
+        // to crash findRawByUid() with a TypeError under strict_types (issue
+        // #129, case 1).
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => ['foo' => 'x']]);
+
+        self::assertSame('Absenden', $this->fetchValue(5), 'A malformed update key must leave every record untouched.');
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewKeyThatIsNotAnInteger(): void
+    {
+        // Same defect on the new[] side: a non-numeric array key (e.g. from a
+        // hand-crafted request) reaches this method as a string.
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => ['foo' => 'x']]);
+
+        self::assertSame(1, $this->countRows(placeholder: 'submit', languageUid: 0));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsAnUpdateForANonPositiveUid(): void
+    {
+        // update[0]=x and a negative uid can never address a record, findRawByUid()
+        // would just return null for either, and the not-found case counts as
+        // rejected too (see the else branch in translateRecordAction()). The
+        // early guard here only spares a pointless lookup, it is not what
+        // decides the outcome.
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [0 => 'x', -3 => 'y']]);
+
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsAnUpdateForAUidThatDoesNotExist(): void
+    {
+        // update[999999]=x is well-formed (a positive int key, a string value)
+        // but does not resolve to a record, e.g. deleted between page load and
+        // submit, or a tampered value. Before this fix it was neither accepted
+        // nor rejected, so it was dropped without any signal, same as a
+        // malformed entry used to be before issue #129.
+        $this->dispatchTranslateRecord(['parent' => '1', 'update' => [5 => 'Absenden!', 999999 => 'Ghost']]);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewEntryWhenTheParentHasNoEnvironmentComponentOrType(): void
+    {
+        // Parent uid 12 carries environment/component/type = 0, the orphaned-row
+        // shape issue #100 already guards against on the update[] side.
+        // saveNewTranslation() returns false for it (createTranslationFromParent()
+        // refuses to build a translation without a real parent relation), and
+        // that must count as rejected too, or a tampered/orphaned parent
+        // silently swallows new[] entries with no signal.
+        $this->dispatchTranslateRecord(['parent' => '12', 'new' => [1 => 'Some text']]);
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrtextdb_domain_model_translation');
+
+        self::assertSame(
+            0,
+            (int) $connection->count(
+                'uid',
+                'tx_nrtextdb_domain_model_translation',
+                [
+                    'placeholder'      => 'orphan_test',
+                    'sys_language_uid' => 1,
+                ],
+            ),
+            'A parent without environment/component/type must not produce a new row.',
+        );
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsTheWholeNewPayloadWhenTheParentDoesNotExist(): void
+    {
+        // $parent itself does not resolve to a record (tampered or stale
+        // uid). Every new[] entry is unreachable in that case, and dropping
+        // the whole payload without a signal would defeat the same guarantee
+        // the per-entry checks give: a mixed request with a valid update[]
+        // entry alongside it must still warn about the lost new[] payload,
+        // not just report the unrelated update[] success.
+        $this->dispatchTranslateRecord(['parent' => '999999', 'new' => [0 => 'Some text'], 'update' => [5 => 'Absenden!']]);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordDoesNotWarnWhenTheInvalidParentHasNoNewPayload(): void
+    {
+        // The parent-not-found rejection only applies when new[] actually
+        // carries a payload that becomes unreachable. An update[]-only save
+        // against a stale/tampered parent id must not spuriously warn about a
+        // "lost" new[] submission that was never there.
+        $this->dispatchTranslateRecord(['parent' => '999999', 'update' => [5 => 'Absenden!']]);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            ['OK' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')]],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordDoesNotWarnWhenTheInvalidParentsNewPayloadIsAllBlank(): void
+    {
+        // A real dialog submit posts one empty new[<language>] textarea per
+        // untranslated language on every save. If the parent happened to be
+        // deleted in the meantime, an editor who only touched the update[]
+        // side must not be told their untouched textareas "could not be
+        // saved", there was nothing there to lose.
+        $this->dispatchTranslateRecord(['parent' => '999999', 'new' => [1 => '   '], 'update' => [5 => 'Absenden!']]);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            ['OK' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')]],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordWarnsWhenTheInvalidParentsNewPayloadIsMalformed(): void
+    {
+        // A malformed (non-string) new[] value is a payload, not a blank, so
+        // it must count towards the "lost payload" warning the same way a
+        // real typed value does, even though the parent doesn't exist either.
+        $this->dispatchTranslateRecord(['parent' => '999999', 'new' => [0 => ['x']], 'update' => [5 => 'Absenden!']]);
+
+        self::assertSame('Absenden!', $this->fetchValue(5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordQueuesNoFlashMessageForAnEmptySubmission(): void
+    {
+        // parent alone, without any new[]/update[] payload, is a no-op: not a
+        // rejection (nothing was submitted to reject) and not a save either.
+        $this->dispatchTranslateRecord(['parent' => '1']);
+
+        self::assertSame([], $this->flashMessagesGroupedBySeverity());
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewEntryForALanguageThatIsNotConfiguredOnTheFirstSite(): void
+    {
+        // new[999]=Text reaches this method with a syntactically valid but
+        // meaningless language id. Before the fix this silently persisted a
+        // translation that could never be reached again through the translation
+        // dialog, since that only lists the site's configured languages (issue
+        // #129, case 3). getAllLanguages() resolves the first configured site
+        // only (see TranslationService::getAllLanguages()), hence "first site"
+        // rather than "any site" in this test's name.
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [999 => 'Some text']]);
+
+        self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 999));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSkipsANewEntryForANegativeLanguageId(): void
+    {
+        // The issue notes negative language ids pass through "in the same way"
+        // as out-of-range positive ones. getAllLanguages() never configures a
+        // negative language id, so this is rejected the same way as case 3.
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [-5 => 'Some text']]);
+
+        self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: -5));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordSavesAMixOfValidAndRejectedEntries(): void
+    {
+        // The valid entry is saved and reported. The rejected one is not
+        // silently dropped either, a real dialog submission always carries at
+        // least one valid update[] entry (the record itself, echoed back), so
+        // an "only warn when nothing at all was saved" rule would never fire
+        // for a tampered entry submitted alongside a normal save.
+        $this->dispatchTranslateRecord(['parent' => '1', 'new' => [0 => 'Send it', 999 => 'Rejected']]);
+
+        self::assertSame('Send it', $this->fetchValue(1));
+        self::assertSame(0, $this->countRows(placeholder: 'submit', languageUid: 999));
+        self::assertSame(
+            [
+                'WARNING' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected')],
+                'OK'      => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.saved')],
+            ],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteAcceptsAMalformedUpdateKey(): void
+    {
+        // Confirms the premise of issue #129 end to end: dispatched through the
+        // real Extbase bootstrap rather than called directly, translateRecordAction()
+        // still receives update[foo] with the string key intact, proving Extbase's
+        // property mapping does not enforce the documented array<int, string> shape.
+        $response = $this->dispatchTranslateRecord([
+            'parent' => '1',
+            'update' => ['foo' => 'x'],
+        ]);
+
+        self::assertSame(303, $response->getStatusCode());
+        self::assertStringContainsString('Translation/translated', $response->getHeaderLine('Location'));
+        self::assertSame('Absenden', $this->fetchValue(5));
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteAcceptsAMalformedArrayValue(): void
+    {
+        // The action itself rejects update[1][]=x before touching the record
+        // (see translateRecordSkipsAnUpdateValueThatIsNotAString), but the
+        // forward this action used to return re-rendered the "translated"
+        // view within the SAME request, and Fluid's f:form.textarea
+        // repopulates a field from the request's own submitted value
+        // whenever the field name matches, even a rejected one. Casting the
+        // rejected array to a string to render it crashed the page with
+        // "Array to string conversion", live-reproduced against a real
+        // TYPO3 v14.3 backend before this was changed to a redirect, which
+        // starts a fresh GET with no submitted body left to
+        // repopulate from. A direct translateRecordAction() call cannot
+        // reproduce this, it never renders the forward target's view.
+        $response = $this->dispatchTranslateRecord([
+            'parent' => '1',
+            'update' => [1 => ['x']],
+        ]);
+
+        self::assertSame(303, $response->getStatusCode());
+        self::assertStringContainsString('Translation/translated', $response->getHeaderLine('Location'));
+        self::assertSame('Absenden', $this->fetchValue(5));
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRedirectsInsteadOfForwardingWhenTheParentArgumentFailsToMap(): void
+    {
+        // parent=abc fails Extbase's own int property mapping before
+        // translateRecordAction() ever runs, so this never reaches its
+        // validation at all. The default ActionController::errorAction()
+        // forwards back to the referring "translated" action via a
+        // ForwardResponse, which the Extbase Dispatcher resolves by
+        // re-dispatching within the same request/response, so the browser
+        // never sees it as a real navigation: the address bar and history
+        // entry stay on the failed request (a POST in real module usage,
+        // this dispatch helper always issues a GET, the forward mechanism
+        // is identical either way), and a page refresh would repeat it.
+        // TranslationController overrides errorAction() to redirect there
+        // instead, verified against this exact input: without the
+        // override, this dispatch renders the referring view inline with a
+        // 200 (Failed asserting that 200 is identical to 303); with it,
+        // the browser gets a real 303 to a fresh GET.
+        //
+        // forwardToReferringRequest() only takes that path if a real,
+        // HMAC-signed __referrer is present, exactly what the "translated"
+        // view's own f:form renders into its hidden fields, so this
+        // extracts one from a real render of that view instead of hand-
+        // building an HMAC.
+        $referrer = $this->extractReferrerFields(
+            (string) $this->dispatchModuleAction(
+                'translated',
+                ['uid' => '1'],
+            )->getBody(),
+        );
+
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $referrer,
+        ]);
+
+        self::assertSame(303, $response->getStatusCode());
+        self::assertStringContainsString('Translation/translated', $response->getHeaderLine('Location'));
+        self::assertSame(
+            ['ERROR' => [$GLOBALS['LANG']->sL('LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.error.translation.request')]],
+            $this->flashMessagesGroupedBySeverity(),
+        );
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteFallsBackToTheDefaultErrorResponseWithoutAReferrer(): void
+    {
+        // Without a __referrer at all (e.g. a direct API call), there is no
+        // '@request' to read, so forwardToReferringRequest() returns null
+        // and errorAction() falls back to the framework's own default
+        // response instead of trying to redirect anywhere. A __referrer
+        // that IS present but fails its HMAC validation is a different
+        // case: that throws, it does not fall back.
+        $response = $this->dispatchTranslateRecord(['parent' => 'abc']);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRejectsAReferrerTargetingAnUnroutableAction(): void
+    {
+        // The referrer HMAC scope is installation-global, not bound to this
+        // module, so a validly signed __referrer can name any action,
+        // including one that does not exist as a method at all, or this
+        // controller's own non-routed errorAction() itself. Neither is a
+        // registered route under this module (Configuration/Backend/
+        // Modules.php's controllerActions), so uriFor() cannot build a URI
+        // for it (mutation-verified: an actual allowlist of action names
+        // added ahead of this test did not change its outcome, uriFor()'s
+        // own route lookup already rejects it), and errorAction() falls
+        // through to a plain error response instead of ever redirecting
+        // anywhere.
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $this->buildSignedReferrer('notARegisteredAction'),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRejectsAReferrerFromAnUnroutableForeignController(): void
+    {
+        // Same installation-global HMAC scope as above, but here the
+        // referrer names a real, routable action, just on a different
+        // controller (as any other Extbase backend module's own form would
+        // sign). "SomeOtherController_list" is not a route this module
+        // registers either, so this hits the exact same uriFor() rejection
+        // as the unroutable-action case above, not a dedicated controller
+        // check (mutation-verified, this test still passes with no
+        // controller-name check present at all).
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $this->buildSignedReferrer('list', 'SomeOtherController'),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateRecordThroughTheRouteRejectsAReferrerFromAForeignExtension(): void
+    {
+        // Same as the two cases above, but with a matching controller/
+        // action pair from a different extension entirely ('Translation'/
+        // 'list' happens to also be a plausible controller/action pair
+        // elsewhere). uriFor()'s backend routing builds its route
+        // identifier from THIS request's own module, not the referrer, and
+        // never consults extensionName at all, so unlike the two cases
+        // above, this one WOULD build a valid URI for this module's own
+        // Translation/list route (silently honouring a foreign referrer
+        // onto our own module, not redirecting to the foreign extension
+        // itself) and 303 there without errorAction()'s explicit
+        // extensionName check (mutation-verified, removing that check
+        // turns this into a 303).
+        $response = $this->dispatchTranslateRecord([
+            'parent'     => 'abc',
+            '__referrer' => $this->buildSignedReferrer('list', 'Translation', 'SomeOtherExtension'),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
     }
 
     #[Test]
@@ -268,7 +781,6 @@ final class TranslationControllerTest extends FunctionalTestCase
     #[Test]
     public function exportWithAStoredFilterIsCarriedOut(): void
     {
-        $this->writeSiteConfiguration();
         $this->storeFilterConfig(['component' => 1]);
 
         $response = $this->dispatchModuleAction('export');
@@ -288,7 +800,6 @@ final class TranslationControllerTest extends FunctionalTestCase
     {
         // The export filters by component and type, and either one on its own is
         // a filter. Only both being unset means "no filter selected".
-        $this->writeSiteConfiguration();
         $this->storeFilterConfig(['type' => 2]);
 
         $response = $this->dispatchModuleAction('export');
@@ -297,6 +808,9 @@ final class TranslationControllerTest extends FunctionalTestCase
         self::assertSame([], $this->errorFlashMessages());
     }
 
+    /**
+     * @param string $storedConfig Raw payload, as it sits in be_users.uc
+     */
     #[Test]
     public function listingTheModuleTruncatesAFractionalStoredFilter(): void
     {
@@ -314,9 +828,6 @@ final class TranslationControllerTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @param string $storedConfig Raw payload, as it sits in be_users.uc
-     */
     #[Test]
     #[DataProvider('unusableStoredFilterProvider')]
     public function exportWithAnUnusableStoredFilterIsRefused(string $storedConfig): void
@@ -353,7 +864,6 @@ final class TranslationControllerTest extends FunctionalTestCase
     {
         // The repository signature is (int, int, ?string, ?string), so an array
         // or an int reaching it would be a TypeError under strict_types.
-        $this->writeSiteConfiguration();
         $this->storeFilterConfig(
             [
                 'component'   => 1,
@@ -476,10 +986,9 @@ final class TranslationControllerTest extends FunctionalTestCase
     #[DataProvider('unusablePageNumberProvider')]
     public function listingTheModuleSurvivesAnUnusablePageNumber(string|array $currentPage): void
     {
-        // The page field of the pagination partial has no "required", and the
-        // core puts the emptied value straight into the navigation URL, so the
-        // list view is called with currentPage=. The paginator rejects everything
-        // below its first page with an exception.
+        // The page field of the pagination partial has no "required", so the core
+        // puts an emptied value into the navigation URL as currentPage=. The
+        // paginator rejects everything below its first page with an exception.
         $response = $this->dispatchModuleAction('list', ['currentPage' => $currentPage]);
 
         self::assertSame(200, $response->getStatusCode());
@@ -506,12 +1015,14 @@ final class TranslationControllerTest extends FunctionalTestCase
      * ActionController::processRequest(), which is the only place that assigns
      * $this->uriBuilder, so the export redirect dies before it is built. The
      * route attribute is what BackendViewFactory and the Extbase request builder
-     * read the module and its controller from. The normalized parameters are
+     * read the module and its controller from, and the normalized parameters are
      * what the page renderer of the module template resolves asset paths with.
      *
-     * @param array<string, string|string[]> $queryParams Backend module arguments
-     *                                                    arrive without a plugin
-     *                                                    namespace
+     * @param array<string, string|array<array-key, string|string[]>> $queryParams
+     *                                                                             Backend module
+     *                                                                             arguments arrive
+     *                                                                             without a plugin
+     *                                                                             namespace
      */
     private function dispatchModuleAction(string $action, array $queryParams = []): ResponseInterface
     {
@@ -536,14 +1047,35 @@ final class TranslationControllerTest extends FunctionalTestCase
     }
 
     /**
-     * Publishes a site with two languages.
+     * Dispatches translateRecordAction() through the real Extbase bootstrap.
      *
-     * The export iterates the languages of the first site. Without one it
-     * produces no file at all. typo3/testing-framework 9 has no helper for this
-     * any more, and a SiteFinder mock via GeneralUtility::addInstance() does not
-     * work here either, because the controller is built by the container. The
-     * configuration is therefore written to the test instance, where tearDown()
-     * removes it again together with its cache.
+     * Calling the action directly skips ActionController::processRequest(),
+     * which is the only place that assigns $this->uriBuilder, so the
+     * translated-view redirect this action returns dies before it is built
+     * (same root cause as dispatchModuleAction()'s own docblock, now hit by
+     * every call since translateRecordAction() started redirecting there
+     * unconditionally, a follow-up hardening found while verifying issue
+     * #129's fix rather than part of #129's original scope).
+     *
+     * @param array<string, string|array<array-key, string|string[]>> $queryParams
+     */
+    private function dispatchTranslateRecord(array $queryParams): ResponseInterface
+    {
+        return $this->dispatchModuleAction('translateRecord', $queryParams);
+    }
+
+    /**
+     * Publishes a site with three languages (English, German, French).
+     *
+     * Called from setUp() for every test: translateRecordAction() now checks
+     * new[] language ids against the site's configured languages (issue
+     * #129), and the export actions iterate the languages of the first site
+     * and produce no file at all without one. typo3/testing-framework 9 has
+     * no helper for this any more, and a SiteFinder mock via
+     * GeneralUtility::addInstance() does not work here either, because the
+     * controller is built by the container. The configuration is therefore
+     * written to the test instance, where tearDown() removes it again
+     * together with its cache.
      */
     private function writeSiteConfiguration(): void
     {
@@ -567,6 +1099,10 @@ final class TranslationControllerTest extends FunctionalTestCase
                     title: German
                     locale: de_DE.UTF-8
                     base: /de/
+                  - languageId: 2
+                    title: French
+                    locale: fr_FR.UTF-8
+                    base: /fr/
                 YAML,
         );
 
@@ -648,24 +1184,109 @@ final class TranslationControllerTest extends FunctionalTestCase
     }
 
     /**
+     * Builds a validly HMAC-signed __referrer[@request] targeting a chosen
+     * controller/action, the same shape forwardToReferringRequest() expects
+     * (ActionController.php), for exercising referrer targets a real
+     * rendered view never points at, such as an action this module does
+     * not register, or a controller belonging to a different module
+     * entirely (the referrer HMAC scope is installation-global).
+     *
+     * @return array<string, string>
+     */
+    private function buildSignedReferrer(
+        string $action,
+        string $controller = 'Translation',
+        string $extension = 'NrTextdb',
+    ): array {
+        $request = json_encode([
+            '@extension'  => $extension,
+            '@controller' => $controller,
+            '@action'     => $action,
+        ], JSON_THROW_ON_ERROR);
+
+        return [
+            '@request' => $this->get(HashService::class)->appendHmac(
+                $request,
+                HashScope::ReferringRequest->prefix(),
+                HashAlgo::SHA3_256,
+            ),
+        ];
+    }
+
+    /**
+     * Extracts the hidden __referrer[...] fields Fluid's f:form renders into
+     * a real view, so a request can be replayed with a real, HMAC-signed
+     * referrer instead of one built by hand.
+     *
+     * @return array<string, string>
+     */
+    private function extractReferrerFields(string $html): array
+    {
+        preg_match_all(
+            '/name="__referrer\[([^"]+)\]" value="([^"]*)"/',
+            $html,
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        $referrer = [];
+
+        foreach ($matches as $match) {
+            $referrer[$match[1]] = htmlspecialchars_decode($match[2]);
+        }
+
+        self::assertArrayHasKey(
+            '@request',
+            $referrer,
+            'The rendered view must contain a __referrer form to extract fields from.',
+        );
+
+        return $referrer;
+    }
+
+    /**
      * Returns the texts of all queued error flash messages.
      *
      * @return string[]
      */
     private function errorFlashMessages(): array
     {
+        return $this->flashMessagesOfSeverity(ContextualFeedbackSeverity::ERROR);
+    }
+
+    /**
+     * Returns the texts of all queued flash messages of the given severity.
+     * Flushes the whole queue, so a second call (of this or any of the three
+     * severity-specific helpers above) returns an empty result. Call at most
+     * once per test, use flashMessagesGroupedBySeverity() directly if more
+     * than one severity needs checking.
+     *
+     * @return string[]
+     */
+    private function flashMessagesOfSeverity(ContextualFeedbackSeverity $severity): array
+    {
+        return $this->flashMessagesGroupedBySeverity()[$severity->name] ?? [];
+    }
+
+    /**
+     * Returns the texts of all queued flash messages, grouped by severity
+     * name. Flushes the whole queue, so call this (or one of the
+     * severity-specific helpers above) at most once per test.
+     *
+     * @return array<string, string[]>
+     */
+    private function flashMessagesGroupedBySeverity(): array
+    {
         $messages = $this->get(FlashMessageService::class)
             ->getMessageQueueByIdentifier()
             ->getAllMessagesAndFlush();
 
-        $texts = [];
+        $grouped = [];
 
         foreach ($messages as $message) {
-            if ($message->getSeverity() === ContextualFeedbackSeverity::ERROR) {
-                $texts[] = $message->getMessage();
-            }
+            $grouped[$message->getSeverity()->name][] = $message->getMessage();
         }
 
-        return $texts;
+        return $grouped;
     }
 }

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -1254,10 +1254,10 @@ final class TranslationControllerTest extends FunctionalTestCase
 
     /**
      * Returns the texts of all queued flash messages of the given severity.
-     * Flushes the whole queue, so a second call (of this or any of the three
-     * severity-specific helpers above) returns an empty result. Call at most
-     * once per test, use flashMessagesGroupedBySeverity() directly if more
-     * than one severity needs checking.
+     * Flushes the whole queue, so a second call (of this or errorFlashMessages())
+     * returns an empty result. Call at most once per test, use
+     * flashMessagesGroupedBySeverity() directly if more than one severity
+     * needs checking.
      *
      * @return string[]
      */
@@ -1268,8 +1268,8 @@ final class TranslationControllerTest extends FunctionalTestCase
 
     /**
      * Returns the texts of all queued flash messages, grouped by severity
-     * name. Flushes the whole queue, so call this (or one of the
-     * severity-specific helpers above) at most once per test.
+     * name. Flushes the whole queue, so call this (or errorFlashMessages() or
+     * flashMessagesOfSeverity() above) at most once per test.
      *
      * @return array<string, string[]>
      */

--- a/Tests/Functional/Controller/TranslationControllerTest.php
+++ b/Tests/Functional/Controller/TranslationControllerTest.php
@@ -31,7 +31,6 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
-use TYPO3\CMS\Core\Crypto\HashAlgo;
 use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
@@ -1208,7 +1207,6 @@ final class TranslationControllerTest extends FunctionalTestCase
             '@request' => $this->get(HashService::class)->appendHmac(
                 $request,
                 HashScope::ReferringRequest->prefix(),
-                HashAlgo::SHA3_256,
             ),
         ];
     }

--- a/Tests/Functional/Fixtures/TranslationRepository/Translations.csv
+++ b/Tests/Functional/Fixtures/TranslationRepository/Translations.csv
@@ -11,3 +11,4 @@
 ,9,1,0,0,0,0,1,0,8,1,1,1,"deleted_entry","Should Not Appear"
 ,10,1,0,0,0,0,0,1,9,1,1,1,"hidden_entry","Hidden Entry"
 ,11,1,0,0,0,0,0,0,10,2,1,1,"submit","Staging Submit"
+,12,1,0,0,0,0,0,0,11,0,0,0,"orphan_test","Orphan"

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
             "a9f/fractor-extension-installer": true,
             "captainhook/hook-installer": true,
             "dg/bypass-finals": true,
+            "ergebnis/composer-normalize": true,
             "infection/extension-installer": true,
             "phpstan/extension-installer": true,
             "typo3/class-alias-loader": true,


### PR DESCRIPTION
## Summary

Backport of #139 (fixes #129 on the `main`/v14.3 line) to the `TYPO3_13` line.

Extbase's property mapping does not enforce the documented `array<int, string>` shape of `translateRecordAction()`'s `new[]`/`update[]` arguments at runtime. A non-int array key, a non-string value, or a language id that is not configured on any site used to crash the action or silently persist an unreachable translation.

- `translateRecordAction()` now validates each entry before it is used, counts accepted and rejected entries, and always redirects back to the referring view instead of forwarding within the same request.
- `errorAction()` is overridden to redirect to the referring request when possible, guarded to this extension's own routable actions, and to fall back to the default error response otherwise.
- Also trusts the `ergebnis/composer-normalize` Composer plugin (a real, non-dev dependency of `netresearch/typo3-ci-workflows` on this line too, confirmed via `composer why`).

This branch's older static-analysis tooling combination (`phpstan/phpstan` 2.2.9 + `saschaegerer/phpstan-typo3` 3.0.0) surfaces two false positives the v14 line doesn't hit; both are handled in `Build/phpstan.neon` with explanatory comments rather than the auto-generated baseline. Three German trans-units that were completely missing on this line (`message.translation.saved`, `message.translation.save.title`, `message.error.translation.save`) were added, matching `main`'s current values, since this fix's new mixed accepted/rejected flash-message batches can now surface the still-untranslated "saved" message right next to the newly translated "rejected" warning in the same response.

## Verification

- `composer ci:test` (lint, phpstan, rector, fractor, unit, functional, cgl) green in this line's own buildbox container.
- Live-verified against a real TYPO3 13.4 backend: malformed update/new payloads and an unconfigured language id all redirect cleanly with the correct flash message, no orphaned rows created.
- Full 7-lens review loop (TYPO3/PHP conventions, general correctness, security, simplification, German writing style, evidence/claim verification, test coverage), two consecutive clean rounds.

## Test plan

- [x] `composer ci:test` green in the TYPO3_13 buildbox
- [x] Functional test suite covers the new validation logic and `errorAction()` branches (~20 new test methods)
- [x] Live-verified malformed `translateRecord` requests against a real TYPO3 13.4 backend
