### PR TITLE
Backport of #139 to TYPO3-11, fixes #129 on the TYPO3-11 line

### DIFF
--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -331,8 +331,27 @@ class TranslationController extends ActionController
         /** @var Translation|null $parentTranslation */
         $parentTranslation = $this->translationRepository->findByUid($parent);
 
+        $somethingRejected = false;
+
         if ($parentTranslation instanceof Translation) {
+            // The documented shape (array<int, string>) is not enforced by
+            // Extbase's property mapping at runtime, and a syntactically valid
+            // but unconfigured sys_language_uid would otherwise silently
+            // occupy a slot of the unique key that the module's own
+            // "untranslated" list can never show or reach again (issue #129).
+            $allowedLanguages = $this->translationService->getAllLanguages();
+
             foreach ($new as $language => $value) {
+                if (
+                    !is_int($language)
+                    || !is_string($value)
+                    || !array_key_exists($language, $allowedLanguages)
+                ) {
+                    $somethingRejected = true;
+
+                    continue;
+                }
+
                 $translation = $this->translationService
                     ->createTranslationFromParent(
                         $parentTranslation,
@@ -342,18 +361,43 @@ class TranslationController extends ActionController
 
                 if ($translation instanceof Translation) {
                     $this->translationRepository->add($translation);
+                } else {
+                    $somethingRejected = true;
                 }
             }
         }
 
         foreach ($update as $translationUid => $value) {
-            /** @var Translation $translation */
+            if (!is_int($translationUid) || ($translationUid <= 0) || !is_string($value)) {
+                $somethingRejected = true;
+
+                continue;
+            }
+
+            /** @var Translation|null $translation */
             $translation = $this->translationRepository->findRecordByUid($translationUid);
+
+            if (!$translation instanceof Translation) {
+                $somethingRejected = true;
+
+                continue;
+            }
+
             $translation->setValue($value);
             $this->translationRepository->update($translation);
         }
 
         $this->persistenceManager->persistAll();
+
+        if ($somethingRejected) {
+            $this->addFlashMessageToQueue(
+                'Translation',
+                $this->getLanguageService()->sL(
+                    'LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.translation.rejected'
+                ),
+                AbstractMessage::WARNING
+            );
+        }
 
         return (new ForwardResponse('translated'))
             ->withControllerName('Translation')
@@ -361,6 +405,53 @@ class TranslationController extends ActionController
             ->withArguments([
                 'uid' => $parent,
             ]);
+    }
+
+    /**
+     * Extbase's own default errorAction() forwards back to the referring view
+     * on any argument-mapping failure (e.g. a non-numeric parent), using a
+     * referrer whose HMAC signature is installation-global rather than scoped
+     * to this extension. Overridden to redirect instead, restricted to an
+     * explicit check that the forward still resolves within this module's own
+     * routes, closing a path where a validly-signed referrer copied from any
+     * other Extbase backend module could otherwise trigger an internal
+     * forward into a foreign controller/action (issue #129).
+     *
+     * @return ResponseInterface
+     */
+    protected function errorAction(): ResponseInterface
+    {
+        $forwardResponse = $this->forwardToReferringRequest();
+
+        if (!$forwardResponse instanceof ForwardResponse) {
+            return parent::errorAction();
+        }
+
+        if ($forwardResponse->getExtensionName() !== 'NrTextdb') {
+            return $this->htmlResponse($this->getFlattenedValidationErrorMessage())
+                ->withStatus(400);
+        }
+
+        $uri = $this->uriBuilder->reset()->uriFor(
+            $forwardResponse->getActionName(),
+            $forwardResponse->getArguments() ?? [],
+            $forwardResponse->getControllerName(),
+            $forwardResponse->getExtensionName(),
+        );
+
+        if ($uri === '') {
+            return $this->htmlResponse($this->getFlattenedValidationErrorMessage())
+                ->withStatus(400);
+        }
+
+        $this->addFlashMessageToQueue(
+            'Translation',
+            $this->getLanguageService()->sL(
+                'LLL:EXT:nr_textdb/Resources/Private/Language/locallang.xlf:message.error.translation.request'
+            )
+        );
+
+        return $this->redirectToUri($uri);
     }
 
     /**

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -105,6 +105,12 @@
             <trans-unit id="message.error.import">
                 <target>Der Dateiname stimmt nicht mit dem erwarteten Muster überein.</target>
             </trans-unit>
+            <trans-unit id="message.translation.rejected">
+                <target>Eine oder mehrere der übermittelten Übersetzungen konnten nicht gespeichert werden. Der Datensatz, die Zielsprache oder der übermittelte Wert war ungültig.</target>
+            </trans-unit>
+            <trans-unit id="message.error.translation.request">
+                <target>Die übermittelte Anfrage konnte nicht verarbeitet werden.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -106,6 +106,12 @@
             <trans-unit id="message.error.import">
                 <source>File name does not match the expected pattern.</source>
             </trans-unit>
+            <trans-unit id="message.translation.rejected">
+                <source>One or more of the submitted translations could not be saved. The record, the target language, or the submitted value was not valid.</source>
+            </trans-unit>
+            <trans-unit id="message.error.translation.request">
+                <source>The submitted request could not be processed.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Netresearch\NrTextdb\Tests\Unit\Controller;
 
 use Netresearch\NrTextdb\Controller\TranslationController;
+use Netresearch\NrTextdb\Domain\Model\Translation;
 use Netresearch\NrTextdb\Domain\Repository\ComponentRepository;
 use Netresearch\NrTextdb\Domain\Repository\TranslationRepository;
 use Netresearch\NrTextdb\Domain\Repository\TypeRepository;
@@ -24,16 +25,23 @@ use ReflectionMethod;
 use ReflectionProperty;
 use RuntimeException;
 use Throwable;
+use TypeError;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\ResponseFactory;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\StreamFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Extbase\Http\ForwardResponse;
+use TYPO3\CMS\Extbase\Mvc\Controller\Arguments;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
 use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 use function glob;
@@ -75,6 +83,19 @@ use function unserialize;
  * plain array read, so testing them through reflection on a real controller
  * instance is a faithful, side-effect-free reproduction of the actual code
  * path, not a mock of the behaviour under test.
+ *
+ * The third group covers issue #129: translateRecordAction() trusted the
+ * array keys and values of new[]/update[] coming straight from the request.
+ * A non-int update[] key reached findRecordByUid('foo') and raised an
+ * uncaught TypeError under strict_types, an array value raised one from
+ * setValue(), and a syntactically valid but unconfigured sys_language_uid
+ * (new[999]=Text) was persisted regardless, permanently occupying a slot of
+ * the unique key for a translation the module's own "untranslated" list
+ * could never show again. errorAction() is covered too: Extbase's own
+ * default implementation forwards back to the referring view using a
+ * referrer whose HMAC signature is installation-global rather than scoped to
+ * this extension, so a validly-signed referrer copied from any other Extbase
+ * backend module could target a foreign controller/action.
  *
  * @author Rico Sonntag <rico.sonntag@netresearch.de>
  */
@@ -422,6 +443,202 @@ final class TranslationControllerTest extends UnitTestCase
             $capturedQueryArguments,
             'listAction() must use the persisted filter unmodified when no request arguments override it.',
         );
+    }
+
+    #[Test]
+    public function translateRecordActionRejectsANonIntegerUpdateKeyWithoutCrashing(): void
+    {
+        // Case 1 of issue #129: update['foo']=x used to reach
+        // findRecordByUid('foo') and raise an uncaught TypeError under
+        // strict_types before the key was ever validated.
+        $translationRepository = self::createMock(TranslationRepository::class);
+        $translationRepository->method('findByUid')->willReturn(null);
+        $translationRepository->expects(self::never())->method('findRecordByUid');
+        $translationRepository->expects(self::never())->method('update');
+
+        $this->wireTranslateRecordActionDependencies($translationRepository);
+
+        try {
+            $this->controller->translateRecordAction(1, [], ['foo' => 'x']);
+        } catch (Throwable $throwable) {
+            self::assertNotInstanceOf(
+                TypeError::class,
+                $throwable,
+                'A non-int update[] key must be rejected before the lookup, not crash it.',
+            );
+        }
+    }
+
+    #[Test]
+    public function translateRecordActionRejectsAnArrayUpdateValueWithoutCrashing(): void
+    {
+        // Case 2 of issue #129: update[1][]=x used to reach setValue() with
+        // an array and raise an uncaught TypeError under strict_types.
+        $translationRepository = self::createMock(TranslationRepository::class);
+        $translationRepository->method('findByUid')->willReturn(null);
+        $translationRepository->expects(self::never())->method('findRecordByUid');
+        $translationRepository->expects(self::never())->method('update');
+
+        $this->wireTranslateRecordActionDependencies($translationRepository);
+
+        try {
+            $this->controller->translateRecordAction(1, [], [1 => ['x']]);
+        } catch (Throwable $throwable) {
+            self::assertNotInstanceOf(
+                TypeError::class,
+                $throwable,
+                'An array update[] value must be rejected before setValue(), not crash it.',
+            );
+        }
+    }
+
+    #[Test]
+    public function translateRecordActionRejectsAWellFormedButNonExistentUpdateUid(): void
+    {
+        // A record deleted between page load and submit, or a tampered but
+        // well-formed uid: findRecordByUid() returns null, and the pre-fix
+        // code called setValue() on it unconditionally.
+        $translationRepository = self::createMock(TranslationRepository::class);
+        $translationRepository->method('findByUid')->willReturn(null);
+        $translationRepository->method('findRecordByUid')->willReturn(null);
+        $translationRepository->expects(self::never())->method('update');
+
+        $this->wireTranslateRecordActionDependencies($translationRepository);
+
+        try {
+            $this->controller->translateRecordAction(1, [], [1 => 'x']);
+        } catch (Throwable) {
+        }
+    }
+
+    #[Test]
+    public function translateRecordActionRejectsAnUnconfiguredLanguageId(): void
+    {
+        // Case 3 of issue #129: new[999]=Text was persisted regardless of
+        // whether language 999 is configured on any site, permanently
+        // occupying a slot of the unique key.
+        $parentTranslation = self::createStub(Translation::class);
+
+        $translationRepository = self::createMock(TranslationRepository::class);
+        $translationRepository->method('findByUid')->willReturn($parentTranslation);
+        $translationRepository->expects(self::never())->method('add');
+
+        $translationService = self::createMock(TranslationService::class);
+        $translationService->method('getAllLanguages')->willReturn([0 => self::createStub(SiteLanguage::class)]);
+        $translationService->expects(self::never())->method('createTranslationFromParent');
+
+        $this->wireTranslateRecordActionDependencies($translationRepository, $translationService);
+
+        try {
+            $this->controller->translateRecordAction(1, [999 => 'Text'], []);
+        } catch (Throwable) {
+        }
+    }
+
+    #[Test]
+    public function translateRecordActionAcceptsAWellFormedSubmission(): void
+    {
+        // The guard above must not reject valid input: a configured language
+        // id with a string value still has to reach createTranslationFromParent().
+        $parentTranslation = self::createStub(Translation::class);
+        $newTranslation    = self::createStub(Translation::class);
+
+        $translationRepository = self::createMock(TranslationRepository::class);
+        $translationRepository->method('findByUid')->willReturn($parentTranslation);
+        $translationRepository->expects(self::once())->method('add')->with($newTranslation);
+
+        $translationService = self::createMock(TranslationService::class);
+        $translationService->method('getAllLanguages')->willReturn([1 => self::createStub(SiteLanguage::class)]);
+        $translationService->expects(self::once())
+            ->method('createTranslationFromParent')
+            ->with($parentTranslation, 1, 'Send it')
+            ->willReturn($newTranslation);
+
+        $this->wireTranslateRecordActionDependencies($translationRepository, $translationService);
+
+        try {
+            $this->controller->translateRecordAction(1, [1 => 'Send it'], []);
+        } catch (Throwable) {
+        }
+    }
+
+    /**
+     * Wires the repositories/services translateRecordAction() needs, stubbed
+     * just enough to observe whether the malformed-input guard let a call
+     * through. persistAll() and addFlashMessageToQueue() run unconditionally
+     * at the end of the action and touch a real backend user session this
+     * reflection-constructed controller never sets up, callers wrap the
+     * action call in try/catch(Throwable) and assert the repository/service
+     * expectations above, which are already satisfied by the time that
+     * happens.
+     */
+    private function wireTranslateRecordActionDependencies(
+        TranslationRepository $translationRepository,
+        ?TranslationService $translationService = null,
+    ): void {
+        // addFlashMessageToQueue() registers a real FlashMessageService
+        // singleton via GeneralUtility::makeInstance(), which UnitTestCase's
+        // tearDown() integrity check flags unless the test declares it expects
+        // that framework state change.
+        $this->resetSingletonInstances = true;
+
+        $GLOBALS['LANG'] = self::createStub(LanguageService::class);
+
+        $this->setControllerProperty('translationRepository', $translationRepository);
+        $this->setControllerProperty('persistenceManager', self::createStub(PersistenceManager::class));
+        $this->setControllerProperty(
+            'translationService',
+            $translationService ?? self::createStub(TranslationService::class),
+        );
+    }
+
+    #[Test]
+    public function errorActionBlocksAForwardIntoAForeignExtension(): void
+    {
+        // The referrer's HMAC signature is installation-global, not scoped to
+        // this extension, so a validly-signed referrer copied from any other
+        // Extbase backend module must still be rejected here (issue #129).
+        // GeneralUtility::hmac() (which HashService delegates to) needs a
+        // non-empty encryption key, UnitTestCase does not seed one.
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = str_repeat('a', 96);
+
+        $hashService = new HashService();
+
+        $referrerRequest = $hashService->appendHmac(
+            json_encode([
+                '@extension'  => 'SomeOtherExtension',
+                '@controller' => 'Foreign',
+                '@action'     => 'index',
+            ]),
+        );
+
+        $this->wireControllerRequest([
+            '__referrer' => [
+                '@request' => $referrerRequest,
+            ],
+        ]);
+        $this->setControllerProperty('hashService', $hashService);
+        // forwardToReferringRequest() attaches $this->arguments->validate() to
+        // the built ForwardResponse; $this->arguments is only ever populated
+        // by initializeActionMethodArguments(), which a Unit test does not run.
+        $this->setControllerProperty('arguments', new Arguments());
+        $this->wireErrorActionResponseFactories();
+
+        $response = $this->invokePrivateMethod('errorAction');
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    /**
+     * Both errorAction() branches under test fall through to htmlResponse(),
+     * which needs the PSR-17 factories a real Bootstrap-dispatched controller
+     * injects via injectResponseFactory()/injectStreamFactory(), neither of
+     * which runs on this reflection-constructed instance.
+     */
+    private function wireErrorActionResponseFactories(): void
+    {
+        $this->setControllerProperty('responseFactory', new ResponseFactory());
+        $this->setControllerProperty('streamFactory', new StreamFactory());
     }
 
     private function setControllerProperty(string $name, object $value): void


### PR DESCRIPTION
## Summary

Backport of #139 to TYPO3-11, fixes #129 on the TYPO3-11 line.

- `translateRecordAction()` trusted the array keys and values of `new[]`/`update[]` straight from the request. A non-int key, a non-string value, or an array value crashed the action with an uncaught `TypeError` under `strict_types`, and a syntactically valid but unconfigured `sys_language_uid` was persisted regardless, permanently occupying a slot of the unique key for a translation that could never be reached again through the dialog.
- Extbase's own default `errorAction()` independently forwards back to the referring view on any argument-mapping failure, using a referrer whose HMAC signature is installation-global rather than scoped to this extension. `TranslationController` now overrides `errorAction()` to redirect there instead, restricted to an explicit check that the forward still resolves within this module's own routes.

This branch's `TranslationController`/`translateRecordAction()` predates the accepted/rejected-counter and redirect-vs-forward refinements that later shipped on main (issue #100 era), and has no `saveNewTranslation()` helper, no `ContextualFeedbackSeverity` enum, and no `translate()` helper. The fix here is written natively against this branch's own API (`AbstractMessage::WARNING`, `$this->getLanguageService()->sL(...)`, `ForwardResponse`) rather than a literal patch of main's version.

## Verification

- Local, containerized (`registry.netresearch.de/support/typo3-11/build:81`, PHP 8.1):
  - `composer ci:test:php:lint`: green.
  - `composer ci:test:php:unit`: 54/54 green (6 new), including the three failure modes from #129 and the `errorAction()` foreign-forward guard. Cross-checked against the unmodified branch HEAD (48 tests, identical 1 warning / 1 notice), so the warning/notice are pre-existing and unrelated to this change.
  - CGL (`php-cs-fixer check --diff`): green except one pre-existing, untouched finding in `ext_emconf.php` (missing `declare(strict_types=1)`), not part of this change.
  - `composer ci:test:php:phpstan` / `ci:test:php:rector`: both fail with the same pre-existing environment error (`Class ...\Domain\Model\Abstract was not found while trying to analyse it`), reproduced identically against the unmodified branch HEAD, so this is not caused by this change.
- This branch has no GitHub Actions build/lint/test CI (`.github/workflows/` only contains `publish-to-ter.yml`), same as the preceding #135/GH-134 merge on this line. Verification above is local/manual, matching that precedent.
- No real TYPO3-11 backend instance was available for a live/browser verification pass, so this PR relies on the local unit-test and CGL results above, not a live-verified check.

## Test plan

- [x] New unit tests reproduce all 3 failure modes from #129 (non-int `update[]` key, array `update[]` value, unconfigured `sys_language_uid`), plus a well-formed-but-non-existent `update[]` uid and a well-formed-input regression guard.
- [x] New unit tests cover `errorAction()` rejecting a forward into a foreign extension.
