### PR TITLE
fix: swap the group and module icon sources back

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -14,10 +14,10 @@ use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 return [
     'extension-netresearch-module' => [
         'provider' => SvgIconProvider::class,
-        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Module.svg',
+        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Extension.svg',
     ],
     'extension-netresearch-textdb' => [
         'provider' => SvgIconProvider::class,
-        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Extension.svg',
+        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Module.svg',
     ],
 ];

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -263,11 +263,11 @@ Icons are registered in `Configuration/Icons.php`:
    return [
        'extension-netresearch-module' => [
            'provider' => SvgIconProvider::class,
-           'source' => 'EXT:nr_textdb/Resources/Public/Icons/Module.svg',
+           'source' => 'EXT:nr_textdb/Resources/Public/Icons/Extension.svg',
        ],
        'extension-netresearch-textdb' => [
            'provider' => SvgIconProvider::class,
-           'source' => 'EXT:nr_textdb/Resources/Public/Icons/Extension.svg',
+           'source' => 'EXT:nr_textdb/Resources/Public/Icons/Module.svg',
        ],
    ];
 


### PR DESCRIPTION
## Problem

The Netresearch group icon and the textdb module icon were registered against each other's file: `extension-netresearch-module` pointed at `Module.svg` (the textdb translation glyph) and `extension-netresearch-textdb` at `Extension.svg` (the Netresearch logo). The backend module menu therefore showed the wrong icon for each.

The mix-up dates back to `b5a70f3` (MFAG-1427, 2024-03) when the `extension-netresearch-*` identifiers were introduced.

## Change

Point the group at `Extension.svg` (the Netresearch logo) and the textdb module at `Module.svg`. Both files exist; only the registration was wrong.