### PR TITLE
fix: swap the group and module icon sources back (v13 backport)

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -14,10 +14,10 @@ use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 return [
     'extension-netresearch-module' => [
         'provider' => SvgIconProvider::class,
-        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Module.svg',
+        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Extension.svg',
     ],
     'extension-netresearch-textdb' => [
         'provider' => SvgIconProvider::class,
-        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Extension.svg',
+        'source'   => 'EXT:nr_textdb/Resources/Public/Icons/Module.svg',
     ],
 ];


### PR DESCRIPTION
Backport of the icon-registration fix to the TYPO3 v13 line. Same swap as on main: the Netresearch group icon and the textdb module icon were registered against each other's file. Point the group at Extension.svg and the textdb module at Module.svg.